### PR TITLE
Implement `OperantLogic.stop_duration` as a distribution instead of scalar value

### DIFF
--- a/src/DataSchemas/aind_behavior_vr_foraging.json
+++ b/src/DataSchemas/aind_behavior_vr_foraging.json
@@ -3013,11 +3013,17 @@
           "type": "boolean"
         },
         "stop_duration": {
-          "default": 0,
-          "description": "Duration (s) the animal must stop for to lock its choice",
-          "minimum": 0,
-          "title": "Stop Duration",
-          "type": "number"
+          "$ref": "#/$defs/Distribution",
+          "default": {
+            "family": "Scalar",
+            "distribution_parameters": {
+              "family": "Scalar",
+              "value": 0.0
+            },
+            "truncation_parameters": null,
+            "scaling_parameters": null
+          },
+          "description": "Duration (s) the animal must stop for to lock its choice"
         },
         "time_to_collect_reward": {
           "default": 100000,

--- a/src/Extensions/AddRewardSite.bonsai
+++ b/src/Extensions/AddRewardSite.bonsai
@@ -121,64 +121,11 @@
                   <Expression xsi:type="SubscribeSubject">
                     <Name>ActivePatch</Name>
                   </Expression>
-                  <Expression xsi:type="MemberSelector">
-                    <Selector>RewardSpecification</Selector>
-                  </Expression>
                   <Expression xsi:type="PropertyMapping">
                     <PropertyMappings>
-                      <Property Name="Delay" Selector="Delay" />
-                    </PropertyMappings>
-                  </Expression>
-                  <Expression xsi:type="SubscribeSubject">
-                    <Name>ActivePatch</Name>
-                  </Expression>
-                  <Expression xsi:type="MemberSelector">
-                    <Selector>RewardSpecification</Selector>
-                  </Expression>
-                  <Expression xsi:type="MemberSelector">
-                    <Selector>OperantLogic</Selector>
-                  </Expression>
-                  <Expression xsi:type="PropertyMapping">
-                    <PropertyMappings>
-                      <Property Name="IsOperant" Selector="IsOperant" />
-                      <Property Name="TimeToCollectReward" Selector="TimeToCollectReward" />
-                      <Property Name="GraceDistanceThreshold" Selector="GraceDistanceThreshold" />
-                    </PropertyMappings>
-                  </Expression>
-                  <Expression xsi:type="SubscribeSubject">
-                    <Name>ActivePatch</Name>
-                  </Expression>
-                  <Expression xsi:type="MemberSelector">
-                    <Selector>RewardSpecification.OperantLogic.StopDuration</Selector>
-                  </Expression>
-                  <Expression xsi:type="SubscribeSubject">
-                    <Name>StopDurationOffset</Name>
-                  </Expression>
-                  <Expression xsi:type="Combinator">
-                    <Combinator xsi:type="rx:CombineLatest" />
-                  </Expression>
-                  <Expression xsi:type="Combinator">
-                    <Combinator xsi:type="rx:Take">
-                      <rx:Count>1</rx:Count>
-                    </Combinator>
-                  </Expression>
-                  <Expression xsi:type="Add" />
-                  <Expression xsi:type="PropertyMapping">
-                    <PropertyMappings>
-                      <Property Name="StopDuration" />
-                    </PropertyMappings>
-                  </Expression>
-                  <Expression xsi:type="Combinator">
-                    <Combinator xsi:type="p1:OperantLogic">
-                      <p1:IsOperant>true</p1:IsOperant>
-                      <p1:StopDuration>0</p1:StopDuration>
-                      <p1:TimeToCollectReward>100000</p1:TimeToCollectReward>
-                      <p1:GraceDistanceThreshold>10</p1:GraceDistanceThreshold>
-                    </Combinator>
-                  </Expression>
-                  <Expression xsi:type="PropertyMapping">
-                    <PropertyMappings>
-                      <Property Name="OperantLogic" />
+                      <Property Name="OperantLogic" Selector="RewardSpecification.OperantLogic" />
+                      <Property Name="Delay" Selector="RewardSpecification.Delay" />
+                      <Property Name="RewardFunction" Selector="RewardSpecification.RewardFunction" />
                     </PropertyMappings>
                   </Expression>
                   <Expression xsi:type="Combinator">
@@ -198,24 +145,10 @@
                 </Nodes>
                 <Edges>
                   <Edge From="0" To="1" Label="Source1" />
-                  <Edge From="1" To="2" Label="Source1" />
-                  <Edge From="2" To="18" Label="Source1" />
-                  <Edge From="3" To="4" Label="Source1" />
+                  <Edge From="1" To="4" Label="Source1" />
+                  <Edge From="2" To="3" Label="Source1" />
+                  <Edge From="3" To="4" Label="Source2" />
                   <Edge From="4" To="5" Label="Source1" />
-                  <Edge From="5" To="6" Label="Source1" />
-                  <Edge From="6" To="14" Label="Source1" />
-                  <Edge From="7" To="8" Label="Source1" />
-                  <Edge From="8" To="10" Label="Source1" />
-                  <Edge From="9" To="10" Label="Source2" />
-                  <Edge From="10" To="11" Label="Source1" />
-                  <Edge From="11" To="12" Label="Source1" />
-                  <Edge From="12" To="13" Label="Source1" />
-                  <Edge From="13" To="14" Label="Source2" />
-                  <Edge From="14" To="15" Label="Source1" />
-                  <Edge From="15" To="18" Label="Source2" />
-                  <Edge From="16" To="17" Label="Source1" />
-                  <Edge From="17" To="18" Label="Source3" />
-                  <Edge From="18" To="19" Label="Source1" />
                 </Edges>
               </Workflow>
             </Expression>

--- a/src/Extensions/AindBehaviorVrForaging.Generated.cs
+++ b/src/Extensions/AindBehaviorVrForaging.Generated.cs
@@ -8336,7 +8336,7 @@ namespace AindVrForagingDataSchema
     
         private bool _isOperant;
     
-        private double _stopDuration;
+        private Distribution _stopDuration;
     
         private double _timeToCollectReward;
     
@@ -8345,7 +8345,7 @@ namespace AindVrForagingDataSchema
         public OperantLogic()
         {
             _isOperant = true;
-            _stopDuration = 0D;
+            _stopDuration = new Distribution();
             _timeToCollectReward = 100000D;
             _graceDistanceThreshold = 10D;
         }
@@ -8378,9 +8378,10 @@ namespace AindVrForagingDataSchema
         /// <summary>
         /// Duration (s) the animal must stop for to lock its choice
         /// </summary>
+        [System.Xml.Serialization.XmlIgnoreAttribute()]
         [Newtonsoft.Json.JsonPropertyAttribute("stop_duration")]
         [System.ComponentModel.DescriptionAttribute("Duration (s) the animal must stop for to lock its choice")]
-        public double StopDuration
+        public Distribution StopDuration
         {
             get
             {
@@ -15281,6 +15282,51 @@ namespace AindVrForagingDataSchema
     [Newtonsoft.Json.JsonConverter(typeof(JsonInheritanceConverter), "family")]
     [Bonsai.WorkflowElementCategoryAttribute(Bonsai.ElementCategory.Source)]
     [Bonsai.CombinatorAttribute(MethodName="Generate")]
+    public partial class Delay
+    {
+    
+        public Delay()
+        {
+        }
+    
+        protected Delay(Delay other)
+        {
+        }
+    
+        public System.IObservable<Delay> Generate()
+        {
+            return System.Reactive.Linq.Observable.Defer(() => System.Reactive.Linq.Observable.Return(new Delay(this)));
+        }
+    
+        public System.IObservable<Delay> Generate<TSource>(System.IObservable<TSource> source)
+        {
+            return System.Reactive.Linq.Observable.Select(source, _ => new Delay(this));
+        }
+    
+        protected virtual bool PrintMembers(System.Text.StringBuilder stringBuilder)
+        {
+            return false;
+        }
+    
+        public override string ToString()
+        {
+            System.Text.StringBuilder stringBuilder = new System.Text.StringBuilder();
+            stringBuilder.Append(GetType().Name);
+            stringBuilder.Append(" { ");
+            if (PrintMembers(stringBuilder))
+            {
+                stringBuilder.Append(" ");
+            }
+            stringBuilder.Append("}");
+            return stringBuilder.ToString();
+        }
+    }
+
+
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("Bonsai.Sgen", "0.6.1.0 (Newtonsoft.Json v13.0.0.0)")]
+    [Newtonsoft.Json.JsonConverter(typeof(JsonInheritanceConverter), "family")]
+    [Bonsai.WorkflowElementCategoryAttribute(Bonsai.ElementCategory.Source)]
+    [Bonsai.CombinatorAttribute(MethodName="Generate")]
     public partial class Amount
     {
     
@@ -16220,6 +16266,45 @@ namespace AindVrForagingDataSchema
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Bonsai.Sgen", "0.6.1.0 (Newtonsoft.Json v13.0.0.0)")]
     [System.ComponentModel.DefaultPropertyAttribute("Type")]
     [Bonsai.WorkflowElementCategoryAttribute(Bonsai.ElementCategory.Combinator)]
+    public partial class MatchDelay : Bonsai.Expressions.SingleArgumentExpressionBuilder
+    {
+    
+        public Bonsai.Expressions.TypeMapping Type { get; set; }
+
+        public override System.Linq.Expressions.Expression Build(System.Collections.Generic.IEnumerable<System.Linq.Expressions.Expression> arguments)
+        {
+            var typeMapping = Type;
+            var returnType = typeMapping != null ? typeMapping.GetType().GetGenericArguments()[0] : typeof(Delay);
+            return System.Linq.Expressions.Expression.Call(
+                typeof(MatchDelay),
+                "Process",
+                new System.Type[] { returnType },
+                System.Linq.Enumerable.Single(arguments));
+        }
+
+    
+        private static System.IObservable<TResult> Process<TResult>(System.IObservable<Delay> source)
+            where TResult : Delay
+        {
+            return System.Reactive.Linq.Observable.Create<TResult>(observer =>
+            {
+                var sourceObserver = System.Reactive.Observer.Create<Delay>(
+                    value =>
+                    {
+                        var match = value as TResult;
+                        if (match != null) observer.OnNext(match);
+                    },
+                    observer.OnError,
+                    observer.OnCompleted);
+                return System.ObservableExtensions.SubscribeSafe(source, sourceObserver);
+            });
+        }
+    }
+
+
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("Bonsai.Sgen", "0.6.1.0 (Newtonsoft.Json v13.0.0.0)")]
+    [System.ComponentModel.DefaultPropertyAttribute("Type")]
+    [Bonsai.WorkflowElementCategoryAttribute(Bonsai.ElementCategory.Combinator)]
     public partial class MatchAmount : Bonsai.Expressions.SingleArgumentExpressionBuilder
     {
     
@@ -17093,6 +17178,11 @@ namespace AindVrForagingDataSchema
             return Process<AindBehaviorVrForagingTaskLogicVector3>(source);
         }
 
+        public System.IObservable<string> Process(System.IObservable<Delay> source)
+        {
+            return Process<Delay>(source);
+        }
+
         public System.IObservable<string> Process(System.IObservable<Amount> source)
         {
             return Process<Amount>(source);
@@ -17264,6 +17354,7 @@ namespace AindVrForagingDataSchema
     [System.Xml.Serialization.XmlIncludeAttribute(typeof(Bonsai.Expressions.TypeMapping<WebCamera>))]
     [System.Xml.Serialization.XmlIncludeAttribute(typeof(Bonsai.Expressions.TypeMapping<AindBehaviorServicesRigVisualStimulationVector3>))]
     [System.Xml.Serialization.XmlIncludeAttribute(typeof(Bonsai.Expressions.TypeMapping<AindBehaviorVrForagingTaskLogicVector3>))]
+    [System.Xml.Serialization.XmlIncludeAttribute(typeof(Bonsai.Expressions.TypeMapping<Delay>))]
     [System.Xml.Serialization.XmlIncludeAttribute(typeof(Bonsai.Expressions.TypeMapping<Amount>))]
     [System.Xml.Serialization.XmlIncludeAttribute(typeof(Bonsai.Expressions.TypeMapping<Probability>))]
     [System.Xml.Serialization.XmlIncludeAttribute(typeof(Bonsai.Expressions.TypeMapping<Available>))]

--- a/src/Extensions/InstantiateSite.bonsai
+++ b/src/Extensions/InstantiateSite.bonsai
@@ -3,11 +3,11 @@
                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                  xmlns:rx="clr-namespace:Bonsai.Reactive;assembly=Bonsai.Core"
                  xmlns:scr="clr-namespace:Bonsai.Scripting.Expressions;assembly=Bonsai.Scripting.Expressions"
-                 xmlns:gl="clr-namespace:Bonsai.Shaders;assembly=Bonsai.Shaders"
                  xmlns:p1="clr-namespace:AindVrForagingDataSchema;assembly=Extensions"
+                 xmlns:p2="clr-namespace:AllenNeuralDynamics.Core;assembly=AllenNeuralDynamics.Core"
+                 xmlns:gl="clr-namespace:Bonsai.Shaders;assembly=Bonsai.Shaders"
                  xmlns:dsp="clr-namespace:Bonsai.Dsp;assembly=Bonsai.Dsp"
                  xmlns:harp="clr-namespace:Bonsai.Harp;assembly=Bonsai.Harp"
-                 xmlns:p2="clr-namespace:AllenNeuralDynamics.Core;assembly=AllenNeuralDynamics.Core"
                  xmlns:p3="clr-namespace:Bonsai.Numerics.Distributions;assembly=Bonsai.Numerics"
                  xmlns:bv="clr-namespace:BonVision;assembly=BonVision"
                  xmlns="https://bonsai-rx.org/2018/workflow">
@@ -151,8 +151,25 @@
                               <Expression xsi:type="MemberSelector">
                                 <Selector>OperantLogic.StopDuration</Selector>
                               </Expression>
+                              <Expression xsi:type="Combinator">
+                                <Combinator xsi:type="p1:SampleDistribution" />
+                              </Expression>
+                              <Expression xsi:type="SubscribeSubject">
+                                <Name>StopDurationOffset</Name>
+                              </Expression>
+                              <Expression xsi:type="Combinator">
+                                <Combinator xsi:type="rx:FirstOrDefault" />
+                              </Expression>
+                              <Expression xsi:type="Combinator">
+                                <Combinator xsi:type="rx:WithLatestFrom" />
+                              </Expression>
+                              <Expression xsi:type="Add" />
                               <Expression xsi:type="scr:ExpressionTransform">
-                                <scr:Expression>TimeSpan.FromSeconds(it)</scr:Expression>
+                                <scr:Name>Math.Max(0, it)</scr:Name>
+                                <scr:Expression>Math.Max(0, it)</scr:Expression>
+                              </Expression>
+                              <Expression xsi:type="Combinator">
+                                <Combinator xsi:type="p2:TimeSpanFromSeconds" />
                               </Expression>
                               <Expression xsi:type="PropertyMapping">
                                 <PropertyMappings>
@@ -161,7 +178,7 @@
                               </Expression>
                               <Expression xsi:type="Combinator">
                                 <Combinator xsi:type="gl:Timer">
-                                  <gl:DueTime>PT0.0000001S</gl:DueTime>
+                                  <gl:DueTime>PT0S</gl:DueTime>
                                 </Combinator>
                               </Expression>
                               <Expression xsi:type="WorkflowInput">
@@ -178,12 +195,18 @@
                             <Edges>
                               <Edge From="0" To="1" Label="Source1" />
                               <Edge From="1" To="2" Label="Source1" />
-                              <Edge From="2" To="3" Label="Source1" />
+                              <Edge From="2" To="5" Label="Source1" />
                               <Edge From="3" To="4" Label="Source1" />
-                              <Edge From="4" To="6" Label="Source1" />
-                              <Edge From="5" To="6" Label="Source2" />
+                              <Edge From="4" To="5" Label="Source2" />
+                              <Edge From="5" To="6" Label="Source1" />
                               <Edge From="6" To="7" Label="Source1" />
                               <Edge From="7" To="8" Label="Source1" />
+                              <Edge From="8" To="9" Label="Source1" />
+                              <Edge From="9" To="10" Label="Source1" />
+                              <Edge From="10" To="12" Label="Source1" />
+                              <Edge From="11" To="12" Label="Source2" />
+                              <Edge From="12" To="13" Label="Source1" />
+                              <Edge From="13" To="14" Label="Source1" />
                             </Edges>
                           </Workflow>
                         </Expression>

--- a/src/aind_behavior_vr_foraging/task_logic.py
+++ b/src/aind_behavior_vr_foraging/task_logic.py
@@ -228,8 +228,10 @@ class OperantLogic(BaseModel):
     """
 
     is_operant: bool = Field(default=True, description="Will the trial implement operant logic")
-    stop_duration: float = Field(
-        default=0, ge=0, description="Duration (s) the animal must stop for to lock its choice"
+    stop_duration: distributions.Distribution = Field(
+        default=scalar_value(0),
+        validate_default=True,
+        description="Duration (s) the animal must stop for to lock its choice",
     )
     time_to_collect_reward: float = Field(
         default=100000, ge=0, description="Time(s) the animal has to collect the reward"


### PR DESCRIPTION
This PR should be fully backwards compatible due to the custom validator implemented in https://github.com/AllenNeuralDynamics/Aind.Behavior.Services/pull/174.
As a result, any numeric values (e.g. the previously typed `float`) that are passed to the annotated type `distributions.Distribution` will be automatically coerced to a `Scalar` type.

While it is technically a breaking change for analysis code downstream, the "true" stop duration should be extracted from real data anyway,.

In addition, the implementation of the `StopDurationOffset` was cleaned up by moving the calculation to the point of reward computation instead of site creation. This is in line with other modifiers that are applied on top of the computation and NOT instantiation. 

Closes #449