### PR TITLE
`SingleSite` curriculum's `learn_to_choose` stage, now sequentially samples blocks

### DIFF
--- a/schema/single_site.json
+++ b/schema/single_site.json
@@ -1112,7 +1112,7 @@
                                     ]
                                 }
                             ],
-                            "sampling_mode": "Random"
+                            "sampling_mode": "Sequential"
                         },
                         "operation_control": {
                             "movable_spout_control": {

--- a/src/packages/aind_behavior_vr_foraging_curricula/src/aind_behavior_vr_foraging_curricula/single_site/README.md
+++ b/src/packages/aind_behavior_vr_foraging_curricula/src/aind_behavior_vr_foraging_curricula/single_site/README.md
@@ -17,7 +17,7 @@ learn_to_stop → learn_to_choose → probability_grid_short_delay → probabili
 | stage | goal | environment | within-session updater | stop / delay |
 |---|---|---|---|---|
 | `learn_to_stop` | a real stop in one session | 2 odors A,B, both `p_reward=1.0` | `STOP_VELOCITY_THRESHOLD` 60→8 (gain ×0.93) | stop **1.0 s** (fixed); delay 0.5 s |
-| `learn_to_choose` | high-contrast discrimination | alternating `(0.9, 0.1)` / `(0.1, 0.9)` blocks | `REWARD_DELAY_OFFSET` 0→0.3 (+0.002) | stop 1.0 s; delay 0.5→0.8 s |
+| `learn_to_choose` | high-contrast discrimination | 2 blocks `(0.9, 0.1)` / `(0.1, 0.9)`, sampled `Sequential` (clean alternation; random block length) | `REWARD_DELAY_OFFSET` 0→0.3 (+0.002) | stop 1.0 s; delay 0.5→0.8 s |
 | `probability_grid_short_delay` | grid + grow patience | 13-block band + distractor C (occ `0.475/0.475/0.05`) | `REWARD_DELAY_OFFSET` 0→1.5 (+0.01) | stop 1.0 s; delay `0.2 + Exp(0.4)`, [0.2, 2.5] s + the ramp |
 | `probability_grid_long_delay` | terminal / analysis | same 13-block band | none | stop 1.0 s; delay `0.2 + Exp(2.1)`, [0.2, 7.0] s (stationary) |
 

--- a/src/packages/aind_behavior_vr_foraging_curricula/src/aind_behavior_vr_foraging_curricula/single_site/stages.py
+++ b/src/packages/aind_behavior_vr_foraging_curricula/src/aind_behavior_vr_foraging_curricula/single_site/stages.py
@@ -125,7 +125,10 @@ def make_s_learn_to_choose() -> Stage:
                             make_patch_kwargs=_POST_STOP_PATCH_KWARGS,
                         ),
                     ],
-                    sampling_mode="Random",
+                    # Two blocks only: Sequential gives clean A-rich -> B-rich
+                    # alternation. Reversal timing is still unpredictable because
+                    # each block's length is random (block_length_exp_mean).
+                    sampling_mode="Sequential",
                 ),
                 operation_control=helpers.make_default_operation_control(velocity_threshold=8),
             ),


### PR DESCRIPTION
learn_to_choose has only two blocks, (0.9, 0.1) and (0.1, 0.9). Random sampling could draw the same reward configuration twice in a row, whereas the stage is meant to alternate A-rich <-> B-rich. Switch to Sequential so the reversal order is deterministic; block length stays random (block_length_exp_mean) so the animal still can't anticipate the timing. The probability_grid_* stages keep Random (random walk over 13 blocks).