### PR TITLE
Infer stream start and end time from data

### DIFF
--- a/scripts/aind.py
+++ b/scripts/aind.py
@@ -264,6 +264,8 @@ class ByAnimalManipulatorModifier(ByAnimalModifier[AindVrForagingRig]):
 
 @experiment()
 async def recover_session(launcher: Launcher) -> None:
+    import datetime
+
     # Start experiment setup
     picker = DataversePicker(launcher=launcher, settings=_DEFAULT_PICKER_SETTINGS)
     session_path = Path(
@@ -296,6 +298,18 @@ async def recover_session(launcher: Launcher) -> None:
     # Mappers
     assert launcher.repository.working_tree_dir is not None
 
+    session_end_time: datetime.datetime | None = None
+    while session_end_time is None:
+        try:
+            s = launcher.ui_helper.input(
+                "Enter the session end time in ISO format (YYYY-MM-DDTHH:MM:SSz), e.g: 2024-01-01T12:00:00Z:"
+            )
+            session_end_time = datetime.datetime.fromisoformat(s)
+        except ValueError:
+            logger.error(
+                "Invalid date format. Please enter the date in ISO format (YYYY-MM-DDTHH:MM:SSz)."
+            )
+
     DataMapperCli(
         data_path=launcher.session_directory,
         repository_path=launcher.repository.working_tree_dir,  # type: ignore[arg-type]
@@ -303,7 +317,7 @@ async def recover_session(launcher: Launcher) -> None:
         curriculum_repository_path=curriculum_settings.project_directory
         if curriculum_settings
         else None,
-        session_end_time=utcnow(),
+        session_end_time=session_end_time,
     ).cli_cmd()
 
     # Run data qc

--- a/src/Extensions/Logging.bonsai
+++ b/src/Extensions/Logging.bonsai
@@ -16,8 +16,8 @@
                  xmlns:p9="clr-namespace:AllenNeuralDynamics.EnvironmentSensor;assembly=AllenNeuralDynamics.EnvironmentSensor"
                  xmlns:harp="clr-namespace:Bonsai.Harp;assembly=Bonsai.Harp"
                  xmlns:p10="clr-namespace:AllenNeuralDynamics.HarpUtils;assembly=AllenNeuralDynamics.HarpUtils"
-                 xmlns:p11="clr-namespace:AllenNeuralDynamics.VersionControl;assembly=AllenNeuralDynamics.VersionControl"
-                 xmlns:p12="clr-namespace:;assembly=Extensions"
+                 xmlns:p11="clr-namespace:;assembly=Extensions"
+                 xmlns:p12="clr-namespace:AllenNeuralDynamics.VersionControl;assembly=AllenNeuralDynamics.VersionControl"
                  xmlns:gl="clr-namespace:Bonsai.Shaders;assembly=Bonsai.Shaders"
                  xmlns:p13="clr-namespace:AindVrForagingDataSchema;assembly=Extensions"
                  xmlns="https://bonsai-rx.org/2018/workflow">
@@ -1071,27 +1071,11 @@ it.Value.SyncQuadValue.Value as SyncQuadValue)</scr:Expression>
                           <Workflow>
                             <Nodes>
                               <Expression xsi:type="SubscribeSubject">
-                                <Name>Repository</Name>
-                              </Expression>
-                              <Expression xsi:type="Combinator">
-                                <Combinator xsi:type="p11:IsRepositoryClean">
-                                  <p11:IgnoreUntracked>false</p11:IgnoreUntracked>
-                                </Combinator>
-                              </Expression>
-                              <Expression xsi:type="Combinator">
-                                <Combinator xsi:type="p1:CreateSoftwareEvent">
-                                  <p1:EventName>RepositoryStatus</p1:EventName>
-                                </Combinator>
-                              </Expression>
-                              <Expression xsi:type="MulticastSubject">
-                                <Name>SoftwareEvent</Name>
-                              </Expression>
-                              <Expression xsi:type="SubscribeSubject">
                                 <Name>ExperimentCommand</Name>
                               </Expression>
                               <Expression xsi:type="Combinator">
-                                <Combinator xsi:type="p12:FilterExperimentCommand">
-                                  <p12:ExperimentCommand>EndCommand</p12:ExperimentCommand>
+                                <Combinator xsi:type="p11:FilterExperimentCommand">
+                                  <p11:ExperimentCommand>EndCommand</p11:ExperimentCommand>
                                 </Combinator>
                               </Expression>
                               <Expression xsi:type="Combinator">
@@ -1107,6 +1091,50 @@ it.Value.SyncQuadValue.Value as SyncQuadValue)</scr:Expression>
                               <Expression xsi:type="Combinator">
                                 <Combinator xsi:type="p1:CreateSoftwareEvent">
                                   <p1:EventName>EndSession</p1:EventName>
+                                </Combinator>
+                              </Expression>
+                              <Expression xsi:type="MulticastSubject">
+                                <Name>SoftwareEvent</Name>
+                              </Expression>
+                              <Expression xsi:type="Combinator">
+                                <Combinator xsi:type="rx:Timestamp" />
+                              </Expression>
+                              <Expression xsi:type="MemberSelector">
+                                <Selector>Timestamp.UtcDateTime</Selector>
+                              </Expression>
+                              <Expression xsi:type="Combinator">
+                                <Combinator xsi:type="p1:CreateSoftwareEvent">
+                                  <p1:EventName>EndSessionTime</p1:EventName>
+                                </Combinator>
+                              </Expression>
+                              <Expression xsi:type="MulticastSubject">
+                                <Name>SoftwareEvent</Name>
+                              </Expression>
+                              <Expression xsi:type="SubscribeSubject">
+                                <Name>Repository</Name>
+                              </Expression>
+                              <Expression xsi:type="Combinator">
+                                <Combinator xsi:type="p12:IsRepositoryClean">
+                                  <p12:IgnoreUntracked>false</p12:IgnoreUntracked>
+                                </Combinator>
+                              </Expression>
+                              <Expression xsi:type="Combinator">
+                                <Combinator xsi:type="p1:CreateSoftwareEvent">
+                                  <p1:EventName>RepositoryStatus</p1:EventName>
+                                </Combinator>
+                              </Expression>
+                              <Expression xsi:type="MulticastSubject">
+                                <Name>SoftwareEvent</Name>
+                              </Expression>
+                              <Expression xsi:type="Combinator">
+                                <Combinator xsi:type="rx:Timestamp" />
+                              </Expression>
+                              <Expression xsi:type="MemberSelector">
+                                <Selector>Timestamp.UtcDateTime</Selector>
+                              </Expression>
+                              <Expression xsi:type="Combinator">
+                                <Combinator xsi:type="p1:CreateSoftwareEvent">
+                                  <p1:EventName>StartSessionTime</p1:EventName>
                                 </Combinator>
                               </Expression>
                               <Expression xsi:type="MulticastSubject">
@@ -1128,6 +1156,7 @@ it.Value.SyncQuadValue.Value as SyncQuadValue)</scr:Expression>
                               <Edge From="0" To="1" Label="Source1" />
                               <Edge From="1" To="2" Label="Source1" />
                               <Edge From="2" To="3" Label="Source1" />
+                              <Edge From="3" To="4" Label="Source1" />
                               <Edge From="4" To="5" Label="Source1" />
                               <Edge From="5" To="6" Label="Source1" />
                               <Edge From="6" To="7" Label="Source1" />
@@ -1135,6 +1164,13 @@ it.Value.SyncQuadValue.Value as SyncQuadValue)</scr:Expression>
                               <Edge From="8" To="9" Label="Source1" />
                               <Edge From="10" To="11" Label="Source1" />
                               <Edge From="11" To="12" Label="Source1" />
+                              <Edge From="12" To="13" Label="Source1" />
+                              <Edge From="13" To="14" Label="Source1" />
+                              <Edge From="14" To="15" Label="Source1" />
+                              <Edge From="15" To="16" Label="Source1" />
+                              <Edge From="16" To="17" Label="Source1" />
+                              <Edge From="18" To="19" Label="Source1" />
+                              <Edge From="19" To="20" Label="Source1" />
                             </Edges>
                           </Workflow>
                         </Expression>

--- a/src/packages/aind_behavior_vr_foraging/src/aind_behavior_vr_foraging/data_contract/v1.py
+++ b/src/packages/aind_behavior_vr_foraging/src/aind_behavior_vr_foraging/data_contract/v1.py
@@ -384,6 +384,20 @@ def dataset(
                                     root_path / "behavior/SoftwareEvents/EndSession.json"
                                 ),
                             ),
+                            SoftwareEvents(
+                                name="SessionStartTime",
+                                description="An event emitted at the start of the session. Data contains a UTC timestamp of the session start time.",
+                                reader_params=SoftwareEvents.make_params(
+                                    root_path / "behavior/SoftwareEvents/SessionStartTime.json"
+                                ),
+                            ),
+                            SoftwareEvents(
+                                name="SessionEndTime",
+                                description="An event emitted at the end of the session. Data contains a UTC timestamp of the session end time.",
+                                reader_params=SoftwareEvents.make_params(
+                                    root_path / "behavior/SoftwareEvents/SessionEndTime.json"
+                                ),
+                            ),
                         ],
                     ),
                     DataStreamCollection(

--- a/src/packages/aind_behavior_vr_foraging/src/aind_behavior_vr_foraging/data_mappers/__init__.py
+++ b/src/packages/aind_behavior_vr_foraging/src/aind_behavior_vr_foraging/data_mappers/__init__.py
@@ -22,9 +22,8 @@ class DataMapperCli(BaseSettings, cli_kebab_case=True):
         default=None,
         description="Path to the curriculum repository. If not provided, will use the repository path.",
     )
-    session_end_time: AwareDatetime | None = Field(
-        default=None,
-        description="End time of the session in ISO format. If not provided, will use the time the data mapping is run.",
+    session_end_time: AwareDatetime = Field(
+        description="End time of the session in ISO format. If not provided, will use the time the data mapping is run."
     )
     suffix: t.Optional[str] = Field(default="vrforaging", description="Suffix to append to the output filenames.")
 

--- a/src/packages/aind_behavior_vr_foraging/src/aind_behavior_vr_foraging/data_mappers/_acquisition.py
+++ b/src/packages/aind_behavior_vr_foraging/src/aind_behavior_vr_foraging/data_mappers/_acquisition.py
@@ -1,7 +1,9 @@
 import datetime
+import json
 import logging
 import os
 import sys
+from functools import cached_property
 from pathlib import Path
 from typing import List, Optional, cast, get_args
 
@@ -137,6 +139,44 @@ class AindAcquisitionDataMapper(ads.AindDataSchemaSessionDataMapper):
         )
         return aind_data_schema_session
 
+    @cached_property
+    def _stream_bound_times(self) -> tuple[datetime.datetime, datetime.datetime]:
+        """Get the start and end times for the data stream. This is used to determine the duration of the session."""
+
+        stream_start_path = Path(self._data_path) / "behavior/SoftwareEvents/SessionStartTime.json"
+        stream_end_path = Path(self._data_path) / "behavior/SoftwareEvents/SessionEndTime.json"
+        stream_start_time: Optional[datetime.datetime] = None
+        stream_end_time: Optional[datetime.datetime] = None
+
+        if stream_start_path.exists():
+            lines = [json.loads(line) for line in stream_start_path.read_text().strip().splitlines() if line.strip()]
+            if lines:
+                stream_start_time = datetime.datetime.fromisoformat(lines[0]["data"])
+        if stream_end_path.exists():
+            lines = [json.loads(line) for line in stream_end_path.read_text().strip().splitlines() if line.strip()]
+            if lines:
+                stream_end_time = datetime.datetime.fromisoformat(lines[-1]["data"])
+
+        if stream_start_time is None:
+            logger.warning("Session start time not found. Using session model date as start time.")
+            stream_start_time = self.session_model.date
+        if stream_end_time is None:
+            logger.error("Session end time not found. Inferring from ActiveSite stream.")
+            json_active_site_path = Path(self._data_path) / "behavior/SoftwareEvents/ActiveSite.json"
+            if json_active_site_path.exists():
+                lines = json_active_site_path.read_text().strip().splitlines()
+                parsed = [json.loads(line) for line in lines if line.strip()]
+                if parsed:
+                    harp_timestamps = [event["timestamp"] for event in parsed]
+                    duration = datetime.timedelta(seconds=max(harp_timestamps) - min(harp_timestamps))
+                    stream_end_time = stream_start_time + duration
+                    logger.info("Inferred session end time from ActiveSite stream: %s", stream_end_time.isoformat())
+        if stream_end_time is None:
+            msg = "Session end time could not be determined. Pass a session end time explicitly to the mapper."
+            logger.error(msg)
+            raise ValueError(msg)
+        return stream_start_time, stream_end_time
+
     def _get_subject_details(self) -> acquisition.AcquisitionSubjectDetails:
         return acquisition.AcquisitionSubjectDetails(
             mouse_platform_name=TrackedDevices.WHEEL,
@@ -182,10 +222,11 @@ class AindAcquisitionDataMapper(ads.AindDataSchemaSessionDataMapper):
         ):
             code.append(self._get_curriculum_as_code())
 
+        stream_start_time, stream_end_time = self._stream_bound_times
         data_streams: list[acquisition.DataStream] = [
             acquisition.DataStream(
-                stream_start_time=self.session_model.date,
-                stream_end_time=self.session_end_time,
+                stream_start_time=stream_start_time,
+                stream_end_time=stream_end_time,
                 code=code,
                 active_devices=active_devices,
                 modalities=modalities,
@@ -286,12 +327,13 @@ class AindAcquisitionDataMapper(ads.AindDataSchemaSessionDataMapper):
             if self.trainer_state.curriculum is not None:
                 training_protocol_name = str(self.trainer_state.curriculum.name)
 
+        start_time, end_time = self._stream_bound_times
         stimulus_epochs: list[acquisition.StimulusEpoch] = [
             acquisition.StimulusEpoch(
                 active_devices=active_devices,
                 code=_stim_code,
-                stimulus_start_time=self.session_model.date,
-                stimulus_end_time=self.session_end_time,
+                stimulus_start_time=start_time,
+                stimulus_end_time=end_time,
                 configurations=stimulus_epoch_configurations,
                 stimulus_name=self.task_model.name,
                 stimulus_modalities=stimulus_modalities,

--- a/src/packages/aind_behavior_vr_foraging/src/aind_behavior_vr_foraging/data_mappers/_acquisition.py
+++ b/src/packages/aind_behavior_vr_foraging/src/aind_behavior_vr_foraging/data_mappers/_acquisition.py
@@ -13,7 +13,7 @@ import pydantic
 from aind_behavior_curriculum import TrainerState
 from aind_behavior_services.rig import cameras, visual_stimulation
 from aind_behavior_services.session import Session
-from aind_behavior_services.utils import get_fields_of_type, model_from_json_file, utcnow
+from aind_behavior_services.utils import get_fields_of_type, model_from_json_file
 from aind_data_schema.components import configs
 from aind_data_schema.core import acquisition
 from aind_data_schema_models import units
@@ -38,14 +38,14 @@ class AindAcquisitionDataMapper(ads.AindDataSchemaSessionDataMapper):
         self,
         data_path: os.PathLike,
         repository_path: os.PathLike,
+        session_end_time: AwareDatetime,
         curriculum_suggestion: Optional[os.PathLike] | CurriculumSuggestion = None,
         curriculum_repository_path: Optional[os.PathLike] = None,
-        session_end_time: Optional[AwareDatetime] = None,
     ):
         self._data_path = data_path
         self._repository_path = repository_path
         self._curriculum_repository_path = curriculum_repository_path
-        self._session_end_time = session_end_time
+        self.session_end_time = session_end_time
 
         abs_schemas_path = Path(self._data_path) / "Behavior" / "Logs"
         self.session_model = model_from_json_file(abs_schemas_path / "session_input.json", Session)
@@ -84,12 +84,6 @@ class AindAcquisitionDataMapper(ads.AindDataSchemaSessionDataMapper):
 
         self._mapped: Optional[acquisition.Acquisition] = None
 
-    @property
-    def session_end_time(self) -> datetime.datetime:
-        if self._session_end_time is None:
-            raise ValueError("Session end time is not set.")
-        return self._session_end_time
-
     def session_schema(self):
         return self.mapped
 
@@ -119,16 +113,12 @@ class AindAcquisitionDataMapper(ads.AindDataSchemaSessionDataMapper):
             return self._mapped
 
     def _map(self) -> acquisition.Acquisition:
-        if self._session_end_time is None:
-            logger.warning("Session end time is not set. Using current time as end time.")
-            self._session_end_time = utcnow()
-
         # Construct aind-data-schema session
         aind_data_schema_session = acquisition.Acquisition(
             subject_id=self.session_model.subject,
             subject_details=self._get_subject_details(),
             instrument_id=self.rig_model.rig_name,
-            acquisition_end_time=utcnow(),
+            acquisition_end_time=self.session_end_time,
             acquisition_start_time=self.session_model.date,
             experimenters=self.session_model.experimenter,
             acquisition_type=self.task_model.name,
@@ -200,8 +190,6 @@ class AindAcquisitionDataMapper(ads.AindDataSchemaSessionDataMapper):
         return True
 
     def _get_data_streams(self) -> List[acquisition.DataStream]:
-        assert self.session_end_time is not None, "Session end time is not set."
-
         modalities: list[Modality] = [getattr(Modality, "BEHAVIOR")]
         if len(self._get_cameras_config()) > 0:
             modalities.append(getattr(Modality, "BEHAVIOR_VIDEOS"))

--- a/src/packages/aind_behavior_vr_foraging/tests/test_aind_data_mapper.py
+++ b/src/packages/aind_behavior_vr_foraging/tests/test_aind_data_mapper.py
@@ -4,13 +4,16 @@ import tempfile
 import unittest
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Sequence
 from unittest.mock import MagicMock, patch
 
 import aind_behavior_curriculum
 from aind_behavior_curriculum import Metrics, Stage, Trainer, create_curriculum
+from aind_behavior_services.data_types import SoftwareEvent
 from aind_data_schema.core import acquisition, instrument
 from aind_data_schema.utils import compatibility_check
 from clabe.apps import CurriculumSuggestion
+from pydantic import TypeAdapter
 
 from aind_behavior_vr_foraging.data_mappers._acquisition import AindAcquisitionDataMapper
 from aind_behavior_vr_foraging.data_mappers._instrument import AindInstrumentDataMapper
@@ -21,6 +24,53 @@ from examples.session import session
 from examples.task_patch_foraging import task_logic
 
 from aind_behavior_vr_foraging.cli import DataMapperCli
+
+MOCK_SESSION_START_TIME = datetime(2023, 1, 1, 11, 0, 0, tzinfo=timezone.utc)
+MOCK_SESSION_END_TIME = datetime(2023, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+MOCK_REWARD_VOLUMES_UL = (5.0, 5.0)
+
+
+def _write_events(path: Path, adapter: TypeAdapter, events: Sequence) -> None:
+    """Serialize ``events`` as one-per-line JSON into ``path``."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("".join(adapter.dump_json(event).decode("utf-8") + "\n" for event in events), encoding="utf-8")
+
+
+def write_mock_software_events(
+    data_path: Path,
+    start_time: datetime = MOCK_SESSION_START_TIME,
+    end_time: datetime = MOCK_SESSION_END_TIME,
+    reward_volumes_ul: Sequence[float] = MOCK_REWARD_VOLUMES_UL,
+) -> None:
+    time_event = TypeAdapter(SoftwareEvent[datetime])
+    reward_event = TypeAdapter(SoftwareEvent[float])
+
+    events_dir = data_path / "behavior" / "SoftwareEvents"
+    _write_events(
+        events_dir / "SessionStartTime.json",
+        time_event,
+        [SoftwareEvent[datetime](name="SessionStartTime", timestamp=0.0, timestamp_source="harp", data=start_time)],
+    )
+    _write_events(
+        events_dir / "SessionEndTime.json",
+        time_event,
+        [
+            SoftwareEvent[datetime](
+                name="SessionEndTime",
+                timestamp=(end_time - start_time).total_seconds(),
+                timestamp_source="harp",
+                data=end_time,
+            )
+        ],
+    )
+    _write_events(
+        events_dir / "GiveReward.json",
+        reward_event,
+        [
+            SoftwareEvent[float](name="GiveReward", timestamp=float(i), timestamp_source="harp", data=volume)
+            for i, volume in enumerate(reward_volumes_ul)
+        ],
+    )
 
 
 class TestAindDataMappers(unittest.TestCase):
@@ -44,7 +94,10 @@ class TestAindDataMappers(unittest.TestCase):
             json.dump(task_logic.model_dump(mode="json"), f, indent=2)
 
         self.repo_path = Path("./")
-        self.session_end_time = datetime(2023, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+        self.session_start_time = MOCK_SESSION_START_TIME
+        self.session_end_time = MOCK_SESSION_END_TIME
+
+        write_mock_software_events(self.data_path)
 
         self.session_mapper = AindAcquisitionDataMapper(
             data_path=self.data_path,
@@ -72,6 +125,22 @@ class TestAindDataMappers(unittest.TestCase):
         mapped = self.session_mapper.map()
         assert mapped is not None
         acquisition.Acquisition.model_validate_json(mapped.model_dump_json())
+
+    def test_mock_software_events_drive_stream_bounds(self):
+        """Stream/stimulus bounds and consumed water come from the SoftwareEvents assets."""
+        mapped = self.session_mapper.map()
+        assert mapped is not None
+
+        stream = mapped.data_streams[0]
+        self.assertEqual(stream.stream_start_time, self.session_start_time)
+        self.assertEqual(stream.stream_end_time, self.session_end_time)
+
+        epoch = mapped.stimulus_epochs[0]
+        self.assertEqual(epoch.stimulus_start_time, self.session_start_time)
+        self.assertEqual(epoch.stimulus_end_time, self.session_end_time)
+
+        expected_consumed_ml = sum(MOCK_REWARD_VOLUMES_UL) * 1e-3
+        self.assertAlmostEqual(float(mapped.subject_details.reward_consumed_total), expected_consumed_ml)
 
     @patch("aind_behavior_vr_foraging.data_mappers._instrument.AindInstrumentDataMapper._map")
     def test_rig_mock_map(self, mock_map):
@@ -170,7 +239,10 @@ class TestCurriculumIntegrationInDataMapper(unittest.TestCase):
         trainer_state_path.write_text(self.curriculum_suggestion.trainer_state.model_dump_json(), encoding="utf-8")
 
         self.repo_path = Path("./")
-        self.session_end_time = datetime(2023, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+        self.session_start_time = MOCK_SESSION_START_TIME
+        self.session_end_time = MOCK_SESSION_END_TIME
+
+        write_mock_software_events(self.data_path)
 
     def tearDown(self):
         self.temp_dir.cleanup()


### PR DESCRIPTION
Session timing in the data mapper no longer relies on a default fallback. It now reads the actual start/end timestamps logged during the session. This is a change to directly address #570 

Changes: 
- **Bonsai logging** — emit `SessionStartTime` / `SessionEndTime` software events (ISO8601).
- **Data contract** (`v1.py`) — register the two new `SessionStartTime` / `SessionEndTime` streams.
- **Acquisition mapper** (`_acquisition.py`) — add `_stream_bound_times`, which derives the stream/stimulus-epoch start & end from the logged events, with graceful fallbacks (session model date → inference from the `ActiveSite` stream → explicit error). Data streams and stimulus epochs now use these inferred bounds instead of `session_model.date` / `session_end_time`. Cached so the files are read once. `session_end_time` is now REQUIRED for the mapper to work.
- **CLI** (`DataMapperCli`) — `session_end_time` is now required rather than silently defaulting to "now".
- **Launcher** (`scripts/aind.py`) — `recover_session` prompts for an ISO session end time instead of defaulting to `utcnow()`. If running at the rig, it will automatically propagate the utcnow as the end time for the session to the mapper.
- **Tests** — generate mock `SoftwareEvents` files from the real `SoftwareEvent[T]` model and assert that stream bounds and consumed water are sourced from them.

### How stream start/end times are resolved
### Two distinct time windows

This PR keeps the top-level **acquisition** window separate from the per-**stream/stimulus** window, and they're sourced differently on purpose:

| Field | Source | Notes |
|---|---|---|
| `acquisition_start_time` | `session_model.date` | When the session was started, from the session model. |
| `acquisition_end_time` | `session_end_time` (constructor arg, **required**) | Must be passed in explicitly; no longer defaults to "now". |
| `data_streams[].stream_start_time` / `stimulus_epochs[].stimulus_start_time` | `_stream_bound_times[0]` | First `SessionStartTime` event; falls back to `session_model.date`. |
| `data_streams[].stream_end_time` / `stimulus_epochs[].stimulus_end_time` | `_stream_bound_times[1]` | Last `SessionEndTime` event; falls back to `ActiveSite`-inferred duration, else raises. |


