### PR TITLE
Remove spout retraction as a feature of the task

### DIFF
--- a/examples/task_mcm.py
+++ b/examples/task_mcm.py
@@ -58,7 +58,6 @@ def compute_cmc_transition_probability(n_states, rep_rate, T=3.5, dt=0.1) -> np.
 
 
 operation_control = vr_task_logic.OperationControl(
-    movable_spout_control=vr_task_logic.MovableSpoutControl(enabled=False),
     audio_control=vr_task_logic.AudioControl(duration=0.2, frequency=9999),
     odor_control=vr_task_logic.OdorControl(),
     position_control=vr_task_logic.PositionControl(

--- a/examples/task_patch_foraging.py
+++ b/examples/task_patch_foraging.py
@@ -34,11 +34,6 @@ updaters = {
 }
 
 operation_control = vr_task_logic.OperationControl(
-    movable_spout_control=vr_task_logic.MovableSpoutControl(
-        enabled=True,
-        time_to_collect_after_reward=1,
-        retracting_distance=2000,
-    ),
     audio_control=vr_task_logic.AudioControl(frequency=1000, duration=0.2),
     odor_control=vr_task_logic.OdorControl(
         target_odor_flow=100, target_total_flow=1000, use_channel_3_as_carrier=True

--- a/examples/test_single_site_patch.py
+++ b/examples/test_single_site_patch.py
@@ -181,7 +181,6 @@ def make_block(
 
 
 operation_control = vr_task_logic.OperationControl(
-    movable_spout_control=vr_task_logic.MovableSpoutControl(enabled=False),
     audio_control=vr_task_logic.AudioControl(duration=0.2, frequency=9999),
     odor_control=vr_task_logic.OdorControl(),
     position_control=vr_task_logic.PositionControl(

--- a/schema/aind_behavior_vr_foraging.json
+++ b/schema/aind_behavior_vr_foraging.json
@@ -579,11 +579,6 @@
                 "duration": 0.2,
                 "frequency": 9999.0
               },
-              "movable_spout_control": {
-                "enabled": false,
-                "retracting_distance": 0.0,
-                "time_to_collect_after_reward": 1.0
-              },
               "odor_control": {
                 "target_odor_flow": 100,
                 "target_total_flow": 1000
@@ -805,11 +800,6 @@
         "operation_control": {
           "$ref": "#/$defs/OperationControl",
           "default": {
-            "movable_spout_control": {
-              "enabled": false,
-              "retracting_distance": 0.0,
-              "time_to_collect_after_reward": 1.0
-            },
             "odor_control": {
               "target_odor_flow": 100,
               "target_total_flow": 1000
@@ -2814,33 +2804,6 @@
       ],
       "x-sgen-typename": "AllenNeuralDynamics.AindManipulator.MotorOperationMode"
     },
-    "MovableSpoutControl": {
-      "description": "Controls the movable water spout behavior for reward delivery.\n\nThis class configures how the movable spout operates, including when it's\nenabled, timing for reward collection, and retraction distance for operant\nconditioning protocols.",
-      "properties": {
-        "enabled": {
-          "default": false,
-          "description": "Whether the movable spout is enabled",
-          "title": "Enabled",
-          "type": "boolean"
-        },
-        "time_to_collect_after_reward": {
-          "default": 1,
-          "description": "Time (s) to collect after reward",
-          "minimum": 0,
-          "title": "Time To Collect After Reward",
-          "type": "number"
-        },
-        "retracting_distance": {
-          "default": 0,
-          "description": "The distance, relative to the default position, the spout will be retracted by",
-          "minimum": 0,
-          "title": "Retracting Distance",
-          "type": "number"
-        }
-      },
-      "title": "MovableSpoutControl",
-      "type": "object"
-    },
     "NormalDistribution": {
       "description": "A normal (Gaussian) probability distribution.\n\nBell-shaped distribution symmetric around the mean, commonly used\nfor modeling naturally occurring random variables.",
       "properties": {
@@ -3286,17 +3249,8 @@
       "type": "object"
     },
     "OperationControl": {
-      "description": "Master control class for all operational hardware systems.\n\nThis class aggregates all the hardware control specifications including\nmovable spout, odor delivery, position tracking, and audio systems.\nIt provides a centralized configuration point for all task hardware.",
+      "description": "Master control class for all operational hardware systems.\n\nThis class aggregates all the hardware control specifications including\nodor delivery, position tracking, and audio systems.\nIt provides a centralized configuration point for all task hardware.",
       "properties": {
-        "movable_spout_control": {
-          "$ref": "#/$defs/MovableSpoutControl",
-          "default": {
-            "enabled": false,
-            "time_to_collect_after_reward": 1.0,
-            "retracting_distance": 0.0
-          },
-          "description": "Control of the movable spout"
-        },
         "odor_control": {
           "$ref": "#/$defs/OdorControl",
           "default": {

--- a/schema/depletion.json
+++ b/schema/depletion.json
@@ -276,11 +276,6 @@
                             "sampling_mode": "Sequential"
                         },
                         "operation_control": {
-                            "movable_spout_control": {
-                                "enabled": false,
-                                "time_to_collect_after_reward": 1.0,
-                                "retracting_distance": 0.0
-                            },
                             "odor_control": {
                                 "target_total_flow": 1000,
                                 "target_odor_flow": 100
@@ -631,11 +626,6 @@
                             "sampling_mode": "Sequential"
                         },
                         "operation_control": {
-                            "movable_spout_control": {
-                                "enabled": false,
-                                "time_to_collect_after_reward": 1.0,
-                                "retracting_distance": 0.0
-                            },
                             "odor_control": {
                                 "target_total_flow": 1000,
                                 "target_odor_flow": 100
@@ -974,11 +964,6 @@
                             "sampling_mode": "Sequential"
                         },
                         "operation_control": {
-                            "movable_spout_control": {
-                                "enabled": false,
-                                "time_to_collect_after_reward": 1.0,
-                                "retracting_distance": 0.0
-                            },
                             "odor_control": {
                                 "target_total_flow": 1000,
                                 "target_odor_flow": 100
@@ -1476,11 +1461,6 @@
                             "sampling_mode": "Sequential"
                         },
                         "operation_control": {
-                            "movable_spout_control": {
-                                "enabled": false,
-                                "time_to_collect_after_reward": 1.0,
-                                "retracting_distance": 0.0
-                            },
                             "odor_control": {
                                 "target_total_flow": 1000,
                                 "target_odor_flow": 100
@@ -2198,11 +2178,6 @@
                             "sampling_mode": "Sequential"
                         },
                         "operation_control": {
-                            "movable_spout_control": {
-                                "enabled": false,
-                                "time_to_collect_after_reward": 1.0,
-                                "retracting_distance": 0.0
-                            },
                             "odor_control": {
                                 "target_total_flow": 1000,
                                 "target_odor_flow": 100

--- a/schema/depletion_stops_offset.json
+++ b/schema/depletion_stops_offset.json
@@ -276,11 +276,6 @@
                             "sampling_mode": "Sequential"
                         },
                         "operation_control": {
-                            "movable_spout_control": {
-                                "enabled": false,
-                                "time_to_collect_after_reward": 1.0,
-                                "retracting_distance": 0.0
-                            },
                             "odor_control": {
                                 "target_total_flow": 1000,
                                 "target_odor_flow": 100
@@ -631,11 +626,6 @@
                             "sampling_mode": "Sequential"
                         },
                         "operation_control": {
-                            "movable_spout_control": {
-                                "enabled": false,
-                                "time_to_collect_after_reward": 1.0,
-                                "retracting_distance": 0.0
-                            },
                             "odor_control": {
                                 "target_total_flow": 1000,
                                 "target_odor_flow": 100
@@ -974,11 +964,6 @@
                             "sampling_mode": "Sequential"
                         },
                         "operation_control": {
-                            "movable_spout_control": {
-                                "enabled": false,
-                                "time_to_collect_after_reward": 1.0,
-                                "retracting_distance": 0.0
-                            },
                             "odor_control": {
                                 "target_total_flow": 1000,
                                 "target_odor_flow": 100
@@ -1476,11 +1461,6 @@
                             "sampling_mode": "Sequential"
                         },
                         "operation_control": {
-                            "movable_spout_control": {
-                                "enabled": false,
-                                "time_to_collect_after_reward": 1.0,
-                                "retracting_distance": 0.0
-                            },
                             "odor_control": {
                                 "target_total_flow": 1000,
                                 "target_odor_flow": 100
@@ -2198,11 +2178,6 @@
                             "sampling_mode": "Sequential"
                         },
                         "operation_control": {
-                            "movable_spout_control": {
-                                "enabled": false,
-                                "time_to_collect_after_reward": 1.0,
-                                "retracting_distance": 0.0
-                            },
                             "odor_control": {
                                 "target_total_flow": 1000,
                                 "target_odor_flow": 100

--- a/schema/depletion_stops_rate.json
+++ b/schema/depletion_stops_rate.json
@@ -276,11 +276,6 @@
                             "sampling_mode": "Sequential"
                         },
                         "operation_control": {
-                            "movable_spout_control": {
-                                "enabled": false,
-                                "time_to_collect_after_reward": 1.0,
-                                "retracting_distance": 0.0
-                            },
                             "odor_control": {
                                 "target_total_flow": 1000,
                                 "target_odor_flow": 100
@@ -631,11 +626,6 @@
                             "sampling_mode": "Sequential"
                         },
                         "operation_control": {
-                            "movable_spout_control": {
-                                "enabled": false,
-                                "time_to_collect_after_reward": 1.0,
-                                "retracting_distance": 0.0
-                            },
                             "odor_control": {
                                 "target_total_flow": 1000,
                                 "target_odor_flow": 100
@@ -974,11 +964,6 @@
                             "sampling_mode": "Sequential"
                         },
                         "operation_control": {
-                            "movable_spout_control": {
-                                "enabled": false,
-                                "time_to_collect_after_reward": 1.0,
-                                "retracting_distance": 0.0
-                            },
                             "odor_control": {
                                 "target_total_flow": 1000,
                                 "target_odor_flow": 100
@@ -1476,11 +1461,6 @@
                             "sampling_mode": "Sequential"
                         },
                         "operation_control": {
-                            "movable_spout_control": {
-                                "enabled": false,
-                                "time_to_collect_after_reward": 1.0,
-                                "retracting_distance": 0.0
-                            },
                             "odor_control": {
                                 "target_total_flow": 1000,
                                 "target_odor_flow": 100
@@ -2198,11 +2178,6 @@
                             "sampling_mode": "Sequential"
                         },
                         "operation_control": {
-                            "movable_spout_control": {
-                                "enabled": false,
-                                "time_to_collect_after_reward": 1.0,
-                                "retracting_distance": 0.0
-                            },
                             "odor_control": {
                                 "target_total_flow": 1000,
                                 "target_odor_flow": 100

--- a/schema/deterministic_reversals.json
+++ b/schema/deterministic_reversals.json
@@ -276,11 +276,6 @@
                             "sampling_mode": "Sequential"
                         },
                         "operation_control": {
-                            "movable_spout_control": {
-                                "enabled": false,
-                                "time_to_collect_after_reward": 1.0,
-                                "retracting_distance": 0.0
-                            },
                             "odor_control": {
                                 "target_total_flow": 1000,
                                 "target_odor_flow": 100
@@ -631,11 +626,6 @@
                             "sampling_mode": "Sequential"
                         },
                         "operation_control": {
-                            "movable_spout_control": {
-                                "enabled": false,
-                                "time_to_collect_after_reward": 1.0,
-                                "retracting_distance": 0.0
-                            },
                             "odor_control": {
                                 "target_total_flow": 1000,
                                 "target_odor_flow": 100
@@ -974,11 +964,6 @@
                             "sampling_mode": "Sequential"
                         },
                         "operation_control": {
-                            "movable_spout_control": {
-                                "enabled": false,
-                                "time_to_collect_after_reward": 1.0,
-                                "retracting_distance": 0.0
-                            },
                             "odor_control": {
                                 "target_total_flow": 1000,
                                 "target_odor_flow": 100
@@ -1490,11 +1475,6 @@
                             "sampling_mode": "Sequential"
                         },
                         "operation_control": {
-                            "movable_spout_control": {
-                                "enabled": false,
-                                "time_to_collect_after_reward": 1.0,
-                                "retracting_distance": 0.0
-                            },
                             "odor_control": {
                                 "target_total_flow": 1000,
                                 "target_odor_flow": 100
@@ -2231,11 +2211,6 @@
                             "sampling_mode": "Sequential"
                         },
                         "operation_control": {
-                            "movable_spout_control": {
-                                "enabled": false,
-                                "time_to_collect_after_reward": 1.0,
-                                "retracting_distance": 0.0
-                            },
                             "odor_control": {
                                 "target_total_flow": 1000,
                                 "target_odor_flow": 100

--- a/schema/deterministic_reversals_reward_capped.json
+++ b/schema/deterministic_reversals_reward_capped.json
@@ -276,11 +276,6 @@
                             "sampling_mode": "Sequential"
                         },
                         "operation_control": {
-                            "movable_spout_control": {
-                                "enabled": false,
-                                "time_to_collect_after_reward": 1.0,
-                                "retracting_distance": 0.0
-                            },
                             "odor_control": {
                                 "target_total_flow": 1000,
                                 "target_odor_flow": 100
@@ -631,11 +626,6 @@
                             "sampling_mode": "Sequential"
                         },
                         "operation_control": {
-                            "movable_spout_control": {
-                                "enabled": false,
-                                "time_to_collect_after_reward": 1.0,
-                                "retracting_distance": 0.0
-                            },
                             "odor_control": {
                                 "target_total_flow": 1000,
                                 "target_odor_flow": 100
@@ -974,11 +964,6 @@
                             "sampling_mode": "Sequential"
                         },
                         "operation_control": {
-                            "movable_spout_control": {
-                                "enabled": false,
-                                "time_to_collect_after_reward": 1.0,
-                                "retracting_distance": 0.0
-                            },
                             "odor_control": {
                                 "target_total_flow": 1000,
                                 "target_odor_flow": 100
@@ -1510,11 +1495,6 @@
                             "sampling_mode": "Sequential"
                         },
                         "operation_control": {
-                            "movable_spout_control": {
-                                "enabled": false,
-                                "time_to_collect_after_reward": 1.0,
-                                "retracting_distance": 0.0
-                            },
                             "odor_control": {
                                 "target_total_flow": 1000,
                                 "target_odor_flow": 100
@@ -2271,11 +2251,6 @@
                             "sampling_mode": "Sequential"
                         },
                         "operation_control": {
-                            "movable_spout_control": {
-                                "enabled": false,
-                                "time_to_collect_after_reward": 1.0,
-                                "retracting_distance": 0.0
-                            },
                             "odor_control": {
                                 "target_total_flow": 1000,
                                 "target_odor_flow": 100

--- a/schema/learning_sets.json
+++ b/schema/learning_sets.json
@@ -11987,11 +11987,6 @@
                             "sampling_mode": "Sequential"
                         },
                         "operation_control": {
-                            "movable_spout_control": {
-                                "enabled": false,
-                                "time_to_collect_after_reward": 1.0,
-                                "retracting_distance": 0.0
-                            },
                             "odor_control": {
                                 "target_total_flow": 1000,
                                 "target_odor_flow": 100
@@ -24001,11 +23996,6 @@
                             "sampling_mode": "Sequential"
                         },
                         "operation_control": {
-                            "movable_spout_control": {
-                                "enabled": false,
-                                "time_to_collect_after_reward": 1.0,
-                                "retracting_distance": 0.0
-                            },
                             "odor_control": {
                                 "target_total_flow": 1000,
                                 "target_odor_flow": 100

--- a/schema/replenishment_depletion_offset.json
+++ b/schema/replenishment_depletion_offset.json
@@ -276,11 +276,6 @@
                             "sampling_mode": "Sequential"
                         },
                         "operation_control": {
-                            "movable_spout_control": {
-                                "enabled": false,
-                                "time_to_collect_after_reward": 1.0,
-                                "retracting_distance": 0.0
-                            },
                             "odor_control": {
                                 "target_total_flow": 1000,
                                 "target_odor_flow": 100
@@ -631,11 +626,6 @@
                             "sampling_mode": "Sequential"
                         },
                         "operation_control": {
-                            "movable_spout_control": {
-                                "enabled": false,
-                                "time_to_collect_after_reward": 1.0,
-                                "retracting_distance": 0.0
-                            },
                             "odor_control": {
                                 "target_total_flow": 1000,
                                 "target_odor_flow": 100
@@ -974,11 +964,6 @@
                             "sampling_mode": "Sequential"
                         },
                         "operation_control": {
-                            "movable_spout_control": {
-                                "enabled": false,
-                                "time_to_collect_after_reward": 1.0,
-                                "retracting_distance": 0.0
-                            },
                             "odor_control": {
                                 "target_total_flow": 1000,
                                 "target_odor_flow": 100
@@ -2086,11 +2071,6 @@
                             "sampling_mode": "Random"
                         },
                         "operation_control": {
-                            "movable_spout_control": {
-                                "enabled": false,
-                                "time_to_collect_after_reward": 1.0,
-                                "retracting_distance": 0.0
-                            },
                             "odor_control": {
                                 "target_total_flow": 1000,
                                 "target_odor_flow": 100

--- a/schema/single_site.json
+++ b/schema/single_site.json
@@ -366,11 +366,6 @@
                             "sampling_mode": "Sequential"
                         },
                         "operation_control": {
-                            "movable_spout_control": {
-                                "enabled": false,
-                                "time_to_collect_after_reward": 1.0,
-                                "retracting_distance": 0.0
-                            },
                             "odor_control": {
                                 "target_total_flow": 1000,
                                 "target_odor_flow": 100
@@ -1115,11 +1110,6 @@
                             "sampling_mode": "Sequential"
                         },
                         "operation_control": {
-                            "movable_spout_control": {
-                                "enabled": false,
-                                "time_to_collect_after_reward": 1.0,
-                                "retracting_distance": 0.0
-                            },
                             "odor_control": {
                                 "target_total_flow": 1000,
                                 "target_odor_flow": 100
@@ -7807,11 +7797,6 @@
                             "sampling_mode": "Random"
                         },
                         "operation_control": {
-                            "movable_spout_control": {
-                                "enabled": false,
-                                "time_to_collect_after_reward": 1.0,
-                                "retracting_distance": 0.0
-                            },
                             "odor_control": {
                                 "target_total_flow": 1000,
                                 "target_odor_flow": 100
@@ -14486,11 +14471,6 @@
                             "sampling_mode": "Random"
                         },
                         "operation_control": {
-                            "movable_spout_control": {
-                                "enabled": false,
-                                "time_to_collect_after_reward": 1.0,
-                                "retracting_distance": 0.0
-                            },
                             "odor_control": {
                                 "target_total_flow": 1000,
                                 "target_odor_flow": 100

--- a/schema/template.json
+++ b/schema/template.json
@@ -561,11 +561,6 @@
                             "sampling_mode": "Random"
                         },
                         "operation_control": {
-                            "movable_spout_control": {
-                                "enabled": true,
-                                "time_to_collect_after_reward": 1.0,
-                                "retracting_distance": 2000.0
-                            },
                             "odor_control": {
                                 "target_total_flow": 1000,
                                 "target_odor_flow": 100
@@ -1165,11 +1160,6 @@
                             "sampling_mode": "Random"
                         },
                         "operation_control": {
-                            "movable_spout_control": {
-                                "enabled": true,
-                                "time_to_collect_after_reward": 1.0,
-                                "retracting_distance": 2000.0
-                            },
                             "odor_control": {
                                 "target_total_flow": 1000,
                                 "target_odor_flow": 100

--- a/src/Extensions/AindBehaviorVrForaging.Generated.cs
+++ b/src/Extensions/AindBehaviorVrForaging.Generated.cs
@@ -4059,126 +4059,6 @@ namespace AindVrForagingDataSchema
 
 
     /// <summary>
-    /// Controls the movable water spout behavior for reward delivery.
-    ///
-    ///This class configures how the movable spout operates, including when it's
-    ///enabled, timing for reward collection, and retraction distance for operant
-    ///conditioning protocols.
-    /// </summary>
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("Bonsai.Sgen", "0.9.0.0 (Newtonsoft.Json v13.0.0.0)")]
-    [System.ComponentModel.DescriptionAttribute("Controls the movable water spout behavior for reward delivery.\n\nThis class config" +
-        "ures how the movable spout operates, including when it\'s\nenabled, timing for rew" +
-        "ard collection, and retraction distance for operant\nconditioning protocols.")]
-    [Bonsai.WorkflowElementCategoryAttribute(Bonsai.ElementCategory.Source)]
-    [Bonsai.CombinatorAttribute(MethodName="Generate")]
-    public partial class MovableSpoutControl
-    {
-    
-        private bool _enabled;
-    
-        private double _timeToCollectAfterReward;
-    
-        private double _retractingDistance;
-    
-        public MovableSpoutControl()
-        {
-            _enabled = false;
-            _timeToCollectAfterReward = 1D;
-            _retractingDistance = 0D;
-        }
-    
-        protected MovableSpoutControl(MovableSpoutControl other)
-        {
-            _enabled = other._enabled;
-            _timeToCollectAfterReward = other._timeToCollectAfterReward;
-            _retractingDistance = other._retractingDistance;
-        }
-    
-        /// <summary>
-        /// Whether the movable spout is enabled
-        /// </summary>
-        [Newtonsoft.Json.JsonPropertyAttribute("enabled")]
-        [System.ComponentModel.DescriptionAttribute("Whether the movable spout is enabled")]
-        public bool Enabled
-        {
-            get
-            {
-                return _enabled;
-            }
-            set
-            {
-                _enabled = value;
-            }
-        }
-    
-        /// <summary>
-        /// Time (s) to collect after reward
-        /// </summary>
-        [Newtonsoft.Json.JsonPropertyAttribute("time_to_collect_after_reward")]
-        [System.ComponentModel.DescriptionAttribute("Time (s) to collect after reward")]
-        public double TimeToCollectAfterReward
-        {
-            get
-            {
-                return _timeToCollectAfterReward;
-            }
-            set
-            {
-                _timeToCollectAfterReward = value;
-            }
-        }
-    
-        /// <summary>
-        /// The distance, relative to the default position, the spout will be retracted by
-        /// </summary>
-        [Newtonsoft.Json.JsonPropertyAttribute("retracting_distance")]
-        [System.ComponentModel.DescriptionAttribute("The distance, relative to the default position, the spout will be retracted by")]
-        public double RetractingDistance
-        {
-            get
-            {
-                return _retractingDistance;
-            }
-            set
-            {
-                _retractingDistance = value;
-            }
-        }
-    
-        public System.IObservable<MovableSpoutControl> Generate()
-        {
-            return System.Reactive.Linq.Observable.Defer(() => System.Reactive.Linq.Observable.Return(new MovableSpoutControl(this)));
-        }
-    
-        public System.IObservable<MovableSpoutControl> Generate<TSource>(System.IObservable<TSource> source)
-        {
-            return System.Reactive.Linq.Observable.Select(source, _ => new MovableSpoutControl(this));
-        }
-    
-        protected virtual bool PrintMembers(System.Text.StringBuilder stringBuilder)
-        {
-            stringBuilder.Append("Enabled = " + _enabled + ", ");
-            stringBuilder.Append("TimeToCollectAfterReward = " + _timeToCollectAfterReward + ", ");
-            stringBuilder.Append("RetractingDistance = " + _retractingDistance);
-            return true;
-        }
-    
-        public override string ToString()
-        {
-            System.Text.StringBuilder stringBuilder = new System.Text.StringBuilder();
-            stringBuilder.Append(GetType().Name);
-            stringBuilder.Append(" { ");
-            if (PrintMembers(stringBuilder))
-            {
-                stringBuilder.Append(" ");
-            }
-            stringBuilder.Append("}");
-            return stringBuilder.ToString();
-        }
-    }
-
-
-    /// <summary>
     /// A numerical updater that modifies task parameters during execution.
     ///
     ///This class combines an operation type with parameters to define how values
@@ -5313,21 +5193,18 @@ namespace AindVrForagingDataSchema
     /// Master control class for all operational hardware systems.
     ///
     ///This class aggregates all the hardware control specifications including
-    ///movable spout, odor delivery, position tracking, and audio systems.
+    ///odor delivery, position tracking, and audio systems.
     ///It provides a centralized configuration point for all task hardware.
     /// </summary>
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Bonsai.Sgen", "0.9.0.0 (Newtonsoft.Json v13.0.0.0)")]
-    [System.ComponentModel.DescriptionAttribute(@"Master control class for all operational hardware systems.
-
-    This class aggregates all the hardware control specifications including
-    movable spout, odor delivery, position tracking, and audio systems.
-    It provides a centralized configuration point for all task hardware.")]
+    [System.ComponentModel.DescriptionAttribute("Master control class for all operational hardware systems.\n\nThis class aggregates" +
+        " all the hardware control specifications including\nodor delivery, position track" +
+        "ing, and audio systems.\nIt provides a centralized configuration point for all ta" +
+        "sk hardware.")]
     [Bonsai.WorkflowElementCategoryAttribute(Bonsai.ElementCategory.Source)]
     [Bonsai.CombinatorAttribute(MethodName="Generate")]
     public partial class OperationControl
     {
-    
-        private MovableSpoutControl _movableSpoutControl;
     
         private OdorControl _odorControl;
     
@@ -5341,7 +5218,6 @@ namespace AindVrForagingDataSchema
     
         public OperationControl()
         {
-            _movableSpoutControl = new MovableSpoutControl();
             _odorControl = new OdorControl();
             _positionControl = new PositionControl();
             _audioControl = new AudioControl();
@@ -5351,30 +5227,11 @@ namespace AindVrForagingDataSchema
     
         protected OperationControl(OperationControl other)
         {
-            _movableSpoutControl = other._movableSpoutControl;
             _odorControl = other._odorControl;
             _positionControl = other._positionControl;
             _audioControl = other._audioControl;
             _waitToStartDuration = other._waitToStartDuration;
             _waitToFinishDuration = other._waitToFinishDuration;
-        }
-    
-        /// <summary>
-        /// Control of the movable spout
-        /// </summary>
-        [System.Xml.Serialization.XmlIgnoreAttribute()]
-        [Newtonsoft.Json.JsonPropertyAttribute("movable_spout_control")]
-        [System.ComponentModel.DescriptionAttribute("Control of the movable spout")]
-        public MovableSpoutControl MovableSpoutControl
-        {
-            get
-            {
-                return _movableSpoutControl;
-            }
-            set
-            {
-                _movableSpoutControl = value;
-            }
         }
     
         /// <summary>
@@ -5477,7 +5334,6 @@ namespace AindVrForagingDataSchema
     
         protected virtual bool PrintMembers(System.Text.StringBuilder stringBuilder)
         {
-            stringBuilder.Append("MovableSpoutControl = " + _movableSpoutControl + ", ");
             stringBuilder.Append("OdorControl = " + _odorControl + ", ");
             stringBuilder.Append("PositionControl = " + _positionControl + ", ");
             stringBuilder.Append("AudioControl = " + _audioControl + ", ");
@@ -12031,11 +11887,6 @@ namespace AindVrForagingDataSchema
             return Process<Measurement>(source);
         }
 
-        public System.IObservable<string> Process(System.IObservable<MovableSpoutControl> source)
-        {
-            return Process<MovableSpoutControl>(source);
-        }
-
         public System.IObservable<string> Process(System.IObservable<NumericalUpdater> source)
         {
             return Process<NumericalUpdater>(source);
@@ -12333,7 +12184,6 @@ namespace AindVrForagingDataSchema
     [System.Xml.Serialization.XmlIncludeAttribute(typeof(Bonsai.Expressions.TypeMapping<LookupTableFunction>))]
     [System.Xml.Serialization.XmlIncludeAttribute(typeof(Bonsai.Expressions.TypeMapping<MarkovEnvironment>))]
     [System.Xml.Serialization.XmlIncludeAttribute(typeof(Bonsai.Expressions.TypeMapping<Measurement>))]
-    [System.Xml.Serialization.XmlIncludeAttribute(typeof(Bonsai.Expressions.TypeMapping<MovableSpoutControl>))]
     [System.Xml.Serialization.XmlIncludeAttribute(typeof(Bonsai.Expressions.TypeMapping<NumericalUpdater>))]
     [System.Xml.Serialization.XmlIncludeAttribute(typeof(Bonsai.Expressions.TypeMapping<NumericalUpdaterParameters>))]
     [System.Xml.Serialization.XmlIncludeAttribute(typeof(Bonsai.Expressions.TypeMapping<OdorControl>))]

--- a/src/Extensions/InstantiateSite.bonsai
+++ b/src/Extensions/InstantiateSite.bonsai
@@ -256,14 +256,6 @@
                                 <Name>ChoiceFeedback</Name>
                               </Expression>
                               <Expression xsi:type="Combinator">
-                                <Combinator xsi:type="BooleanProperty">
-                                  <Value>true</Value>
-                                </Combinator>
-                              </Expression>
-                              <Expression xsi:type="MulticastSubject">
-                                <Name>SpoutAvailable</Name>
-                              </Expression>
-                              <Expression xsi:type="Combinator">
                                 <Combinator xsi:type="rx:Take">
                                   <rx:Count>1</rx:Count>
                                 </Combinator>
@@ -275,8 +267,6 @@
                               <Edge From="1" To="2" Label="Source1" />
                               <Edge From="2" To="3" Label="Source1" />
                               <Edge From="3" To="4" Label="Source1" />
-                              <Edge From="4" To="5" Label="Source1" />
-                              <Edge From="5" To="6" Label="Source1" />
                             </Edges>
                           </Workflow>
                         </Expression>
@@ -838,14 +828,6 @@ it.Item2 as EntryPosition)</scr:Expression>
                             </Edges>
                           </Workflow>
                         </Expression>
-                        <Expression xsi:type="Combinator">
-                          <Combinator xsi:type="BooleanProperty">
-                            <Value>false</Value>
-                          </Combinator>
-                        </Expression>
-                        <Expression xsi:type="MulticastSubject">
-                          <Name>SpoutAvailable</Name>
-                        </Expression>
                         <Expression xsi:type="rx:Condition">
                           <Name>Success</Name>
                           <Workflow>
@@ -1117,26 +1099,24 @@ it.Item2 as EntryPosition)</scr:Expression>
                         <Edge From="13" To="14" Label="Source1" />
                         <Edge From="13" To="16" Label="Source1" />
                         <Edge From="14" To="15" Label="Source1" />
-                        <Edge From="15" To="31" Label="Source1" />
+                        <Edge From="15" To="29" Label="Source1" />
                         <Edge From="16" To="17" Label="Source1" />
-                        <Edge From="16" To="24" Label="Source1" />
+                        <Edge From="16" To="22" Label="Source1" />
                         <Edge From="17" To="18" Label="Source1" />
                         <Edge From="18" To="19" Label="Source1" />
-                        <Edge From="18" To="22" Label="Source1" />
-                        <Edge From="19" To="20" Label="Source1" />
+                        <Edge From="18" To="20" Label="Source1" />
+                        <Edge From="19" To="29" Label="Source2" />
                         <Edge From="20" To="21" Label="Source1" />
-                        <Edge From="21" To="31" Label="Source2" />
+                        <Edge From="21" To="24" Label="Source1" />
                         <Edge From="22" To="23" Label="Source1" />
-                        <Edge From="23" To="26" Label="Source1" />
+                        <Edge From="23" To="24" Label="Source2" />
                         <Edge From="24" To="25" Label="Source1" />
-                        <Edge From="25" To="26" Label="Source2" />
+                        <Edge From="25" To="26" Label="Source1" />
                         <Edge From="26" To="27" Label="Source1" />
                         <Edge From="27" To="28" Label="Source1" />
-                        <Edge From="28" To="29" Label="Source1" />
+                        <Edge From="28" To="29" Label="Source3" />
                         <Edge From="29" To="30" Label="Source1" />
-                        <Edge From="30" To="31" Label="Source3" />
-                        <Edge From="31" To="32" Label="Source1" />
-                        <Edge From="32" To="33" Label="Source1" />
+                        <Edge From="30" To="31" Label="Source1" />
                       </Edges>
                     </Workflow>
                   </Expression>

--- a/src/Extensions/Logging.bonsai
+++ b/src/Extensions/Logging.bonsai
@@ -1269,6 +1269,45 @@ it.Value.SyncQuadValue.Value as SyncQuadValue)</scr:Expression>
                               <Expression xsi:type="MulticastSubject">
                                 <Name>SoftwareEvent</Name>
                               </Expression>
+                              <Expression xsi:type="SubscribeSubject">
+                                <Name>RigSchema</Name>
+                              </Expression>
+                              <Expression xsi:type="MemberSelector">
+                                <Selector>Manipulator.Calibration.InitialPosition</Selector>
+                              </Expression>
+                              <Expression xsi:type="SubscribeSubject">
+                                <Name>ExperimentCommand</Name>
+                              </Expression>
+                              <Expression xsi:type="Combinator">
+                                <Combinator xsi:type="p11:FilterExperimentCommand">
+                                  <p11:ExperimentCommand>EndCommand</p11:ExperimentCommand>
+                                </Combinator>
+                              </Expression>
+                              <Expression xsi:type="SubscribeSubject">
+                                <Name>ManipulatorPosition</Name>
+                              </Expression>
+                              <Expression xsi:type="Combinator">
+                                <Combinator xsi:type="rx:ObserveOn">
+                                  <rx:Scheduler>ThreadPoolScheduler</rx:Scheduler>
+                                </Combinator>
+                              </Expression>
+                              <Expression xsi:type="Combinator">
+                                <Combinator xsi:type="rx:WithLatestFrom" />
+                              </Expression>
+                              <Expression xsi:type="MemberSelector">
+                                <Selector>Item2</Selector>
+                              </Expression>
+                              <Expression xsi:type="Combinator">
+                                <Combinator xsi:type="rx:Merge" />
+                              </Expression>
+                              <Expression xsi:type="Combinator">
+                                <Combinator xsi:type="p1:CreateSoftwareEvent">
+                                  <p1:EventName>SpoutParkingPositions</p1:EventName>
+                                </Combinator>
+                              </Expression>
+                              <Expression xsi:type="MulticastSubject">
+                                <Name>SoftwareEvent</Name>
+                              </Expression>
                             </Nodes>
                             <Edges>
                               <Edge From="0" To="1" Label="Source1" />
@@ -1289,6 +1328,16 @@ it.Value.SyncQuadValue.Value as SyncQuadValue)</scr:Expression>
                               <Edge From="16" To="17" Label="Source1" />
                               <Edge From="18" To="19" Label="Source1" />
                               <Edge From="19" To="20" Label="Source1" />
+                              <Edge From="21" To="22" Label="Source1" />
+                              <Edge From="22" To="29" Label="Source1" />
+                              <Edge From="23" To="24" Label="Source1" />
+                              <Edge From="24" To="27" Label="Source1" />
+                              <Edge From="25" To="26" Label="Source1" />
+                              <Edge From="26" To="27" Label="Source2" />
+                              <Edge From="27" To="28" Label="Source1" />
+                              <Edge From="28" To="29" Label="Source2" />
+                              <Edge From="29" To="30" Label="Source1" />
+                              <Edge From="30" To="31" Label="Source1" />
                             </Edges>
                           </Workflow>
                         </Expression>

--- a/src/Extensions/OperationControl.bonsai
+++ b/src/Extensions/OperationControl.bonsai
@@ -13,12 +13,11 @@
                  xmlns:beh="clr-namespace:Harp.Behavior;assembly=Harp.Behavior"
                  xmlns:p4="clr-namespace:System.Reactive;assembly=System.Reactive.Core"
                  xmlns:bv="clr-namespace:BonVision;assembly=BonVision"
-                 xmlns:p5="clr-namespace:AllenNeuralDynamics.AindManipulator;assembly=AllenNeuralDynamics.AindManipulator"
-                 xmlns:p6="clr-namespace:AllenNeuralDynamics.LicketySplit;assembly=AllenNeuralDynamics.LicketySplit"
-                 xmlns:p7="clr-namespace:AllenNeuralDynamics.SniffDetector;assembly=AllenNeuralDynamics.SniffDetector"
-                 xmlns:p8="clr-namespace:AllenNeuralDynamics.Treadmill;assembly=AllenNeuralDynamics.Treadmill"
+                 xmlns:p5="clr-namespace:AllenNeuralDynamics.LicketySplit;assembly=AllenNeuralDynamics.LicketySplit"
+                 xmlns:p6="clr-namespace:AllenNeuralDynamics.SniffDetector;assembly=AllenNeuralDynamics.SniffDetector"
+                 xmlns:p7="clr-namespace:AllenNeuralDynamics.Treadmill;assembly=AllenNeuralDynamics.Treadmill"
                  xmlns:dsp="clr-namespace:Bonsai.Dsp;assembly=Bonsai.Dsp"
-                 xmlns:p9="clr-namespace:Bonsai.Numerics.Interpolation;assembly=Bonsai.Numerics"
+                 xmlns:p8="clr-namespace:Bonsai.Numerics.Interpolation;assembly=Bonsai.Numerics"
                  xmlns="https://bonsai-rx.org/2018/workflow">
   <Workflow>
     <Nodes>
@@ -918,457 +917,6 @@
         </Workflow>
       </Expression>
       <Expression xsi:type="GroupWorkflow">
-        <Name>MovableSpoutControl</Name>
-        <Workflow>
-          <Nodes>
-            <Expression xsi:type="Annotation">
-              <Name>Start with the spout at max distance</Name>
-              <Text><![CDATA[Start with the spout at max distance]]></Text>
-            </Expression>
-            <Expression xsi:type="Combinator">
-              <Combinator xsi:type="BooleanProperty">
-                <Value>true</Value>
-              </Combinator>
-            </Expression>
-            <Expression xsi:type="Combinator">
-              <Combinator xsi:type="rx:Take">
-                <rx:Count>1</rx:Count>
-              </Combinator>
-            </Expression>
-            <Expression xsi:type="rx:BehaviorSubject">
-              <Name>SpoutAvailable</Name>
-            </Expression>
-            <Expression xsi:type="SubscribeSubject">
-              <Name>SpoutAvailable</Name>
-            </Expression>
-            <Expression xsi:type="SubscribeSubject">
-              <Name>TaskLogicParameters</Name>
-            </Expression>
-            <Expression xsi:type="MemberSelector">
-              <Selector>OperationControl.MovableSpoutControl</Selector>
-            </Expression>
-            <Expression xsi:type="MemberSelector">
-              <Selector>Enabled</Selector>
-            </Expression>
-            <Expression xsi:type="Combinator">
-              <Combinator xsi:type="rx:WithLatestFrom" />
-            </Expression>
-            <Expression xsi:type="rx:Condition">
-              <Name>IsEnabled</Name>
-              <Workflow>
-                <Nodes>
-                  <Expression xsi:type="WorkflowInput">
-                    <Name>Source1</Name>
-                  </Expression>
-                  <Expression xsi:type="MemberSelector">
-                    <Selector>Item2</Selector>
-                  </Expression>
-                  <Expression xsi:type="WorkflowOutput" />
-                </Nodes>
-                <Edges>
-                  <Edge From="0" To="1" Label="Source1" />
-                  <Edge From="1" To="2" Label="Source1" />
-                </Edges>
-              </Workflow>
-            </Expression>
-            <Expression xsi:type="MemberSelector">
-              <Selector>Item1</Selector>
-            </Expression>
-            <Expression xsi:type="SubscribeSubject">
-              <Name>SpoutParkingPositions</Name>
-            </Expression>
-            <Expression xsi:type="Combinator">
-              <Combinator xsi:type="rx:WithLatestFrom" />
-            </Expression>
-            <Expression xsi:type="scr:ExpressionTransform">
-              <scr:Name>GetPosition</scr:Name>
-              <scr:Expression>it.Item1 ? it.Item2.ResetPosition : it.Item2.RetractedPosition</scr:Expression>
-            </Expression>
-            <Expression xsi:type="MulticastSubject">
-              <Name>MoveTo</Name>
-            </Expression>
-            <Expression xsi:type="GroupWorkflow">
-              <Name>InitialState</Name>
-              <Workflow>
-                <Nodes>
-                  <Expression xsi:type="SubscribeSubject">
-                    <Name>ManipulatorPosition</Name>
-                  </Expression>
-                  <Expression xsi:type="Combinator">
-                    <Combinator xsi:type="rx:Take">
-                      <rx:Count>1</rx:Count>
-                    </Combinator>
-                  </Expression>
-                  <Expression xsi:type="SubscribeSubject">
-                    <Name>RigSchema</Name>
-                  </Expression>
-                  <Expression xsi:type="MemberSelector">
-                    <Selector>Manipulator</Selector>
-                  </Expression>
-                  <Expression xsi:type="MemberSelector">
-                    <Selector>SpoutAxis</Selector>
-                  </Expression>
-                  <Expression xsi:type="PropertyMapping">
-                    <PropertyMappings>
-                      <Property Name="Axis" />
-                    </PropertyMappings>
-                  </Expression>
-                  <Expression xsi:type="rx:SelectMany">
-                    <Name>CalculateRetractedPosition</Name>
-                    <Workflow>
-                      <Nodes>
-                        <Expression xsi:type="ExternalizedMapping">
-                          <Property Name="Value" DisplayName="Axis" />
-                        </Expression>
-                        <Expression xsi:type="PropertySource" TypeArguments="p5:AxisConfiguration,p5:Axis">
-                          <MemberName>Axis</MemberName>
-                          <Value>Y1</Value>
-                        </Expression>
-                        <Expression xsi:type="Combinator">
-                          <Combinator xsi:type="rx:Take">
-                            <rx:Count>1</rx:Count>
-                          </Combinator>
-                        </Expression>
-                        <Expression xsi:type="rx:AsyncSubject">
-                          <Name>SpoutAxis</Name>
-                        </Expression>
-                        <Expression xsi:type="WorkflowInput">
-                          <Name>Source1</Name>
-                        </Expression>
-                        <Expression xsi:type="Combinator">
-                          <Combinator xsi:type="rx:Take">
-                            <rx:Count>1</rx:Count>
-                          </Combinator>
-                        </Expression>
-                        <Expression xsi:type="rx:AsyncSubject">
-                          <Name>SpoutResetPosition</Name>
-                        </Expression>
-                        <Expression xsi:type="SubscribeSubject">
-                          <Name>SpoutResetPosition</Name>
-                        </Expression>
-                        <Expression xsi:type="Unit" />
-                        <Expression xsi:type="Combinator">
-                          <Combinator xsi:type="rx:Take">
-                            <rx:Count>1</rx:Count>
-                          </Combinator>
-                        </Expression>
-                        <Expression xsi:type="Combinator">
-                          <Combinator xsi:type="p5:ManipulatorPosition">
-                            <p5:X>0</p5:X>
-                            <p5:Y1>0</p5:Y1>
-                            <p5:Y2>0</p5:Y2>
-                            <p5:Z>0</p5:Z>
-                          </Combinator>
-                        </Expression>
-                        <Expression xsi:type="SubscribeSubject">
-                          <Name>TaskLogicParameters</Name>
-                        </Expression>
-                        <Expression xsi:type="MemberSelector">
-                          <Selector>OperationControl.MovableSpoutControl</Selector>
-                        </Expression>
-                        <Expression xsi:type="MemberSelector">
-                          <Selector>RetractingDistance</Selector>
-                        </Expression>
-                        <Expression xsi:type="Combinator">
-                          <Combinator xsi:type="rx:Zip" />
-                        </Expression>
-                        <Expression xsi:type="SubscribeSubject">
-                          <Name>SpoutAxis</Name>
-                        </Expression>
-                        <Expression xsi:type="PropertyMapping">
-                          <PropertyMappings>
-                            <Property Name="Axis" />
-                          </PropertyMappings>
-                        </Expression>
-                        <Expression xsi:type="Combinator">
-                          <Combinator xsi:type="p1:ModifyManipulatorPosition">
-                            <p1:Axis>None</p1:Axis>
-                          </Combinator>
-                        </Expression>
-                        <Expression xsi:type="Combinator">
-                          <Combinator xsi:type="rx:Zip" />
-                        </Expression>
-                        <Expression xsi:type="Subtract" />
-                        <Expression xsi:type="Combinator">
-                          <Combinator xsi:type="rx:Take">
-                            <rx:Count>1</rx:Count>
-                          </Combinator>
-                        </Expression>
-                        <Expression xsi:type="WorkflowOutput" />
-                      </Nodes>
-                      <Edges>
-                        <Edge From="0" To="1" Label="Source1" />
-                        <Edge From="1" To="2" Label="Source1" />
-                        <Edge From="2" To="3" Label="Source1" />
-                        <Edge From="4" To="5" Label="Source1" />
-                        <Edge From="5" To="6" Label="Source1" />
-                        <Edge From="7" To="18" Label="Source1" />
-                        <Edge From="8" To="9" Label="Source1" />
-                        <Edge From="9" To="10" Label="Source1" />
-                        <Edge From="10" To="14" Label="Source1" />
-                        <Edge From="11" To="12" Label="Source1" />
-                        <Edge From="12" To="13" Label="Source1" />
-                        <Edge From="13" To="14" Label="Source2" />
-                        <Edge From="14" To="17" Label="Source1" />
-                        <Edge From="15" To="16" Label="Source1" />
-                        <Edge From="16" To="17" Label="Source2" />
-                        <Edge From="17" To="18" Label="Source2" />
-                        <Edge From="18" To="19" Label="Source1" />
-                        <Edge From="19" To="20" Label="Source1" />
-                        <Edge From="20" To="21" Label="Source1" />
-                      </Edges>
-                    </Workflow>
-                  </Expression>
-                  <Expression xsi:type="Combinator">
-                    <Combinator xsi:type="rx:Zip" />
-                  </Expression>
-                  <Expression xsi:type="scr:ExpressionTransform">
-                    <scr:Name>Rename</scr:Name>
-                    <scr:Expression>new(Item1 as ResetPosition, Item2 as RetractedPosition)</scr:Expression>
-                  </Expression>
-                  <Expression xsi:type="rx:AsyncSubject">
-                    <Name>SpoutParkingPositions</Name>
-                  </Expression>
-                  <Expression xsi:type="SubscribeSubject">
-                    <Name>SpoutParkingPositions</Name>
-                  </Expression>
-                  <Expression xsi:type="Combinator">
-                    <Combinator xsi:type="p2:CreateSoftwareEvent">
-                      <p2:EventName>SpoutParkingPositions</p2:EventName>
-                    </Combinator>
-                  </Expression>
-                  <Expression xsi:type="MulticastSubject">
-                    <Name>SoftwareEvent</Name>
-                  </Expression>
-                  <Expression xsi:type="SubscribeSubject">
-                    <Name>TaskLogicParameters</Name>
-                  </Expression>
-                  <Expression xsi:type="MemberSelector">
-                    <Selector>OperationControl.MovableSpoutControl</Selector>
-                  </Expression>
-                  <Expression xsi:type="MemberSelector">
-                    <Selector>Enabled</Selector>
-                  </Expression>
-                  <Expression xsi:type="BitwiseNot" />
-                  <Expression xsi:type="MulticastSubject">
-                    <Name>SpoutAvailable</Name>
-                  </Expression>
-                  <Expression xsi:type="SubscribeSubject">
-                    <Name>GiveReward</Name>
-                  </Expression>
-                  <Expression xsi:type="Combinator">
-                    <Combinator xsi:type="BooleanProperty">
-                      <Value>false</Value>
-                    </Combinator>
-                  </Expression>
-                  <Expression xsi:type="SubscribeSubject">
-                    <Name>SpoutAvailable</Name>
-                  </Expression>
-                  <Expression xsi:type="rx:Condition">
-                    <Name>Condition</Name>
-                    <Workflow>
-                      <Nodes>
-                        <Expression xsi:type="WorkflowInput">
-                          <Name>Source1</Name>
-                        </Expression>
-                        <Expression xsi:type="WorkflowOutput" />
-                      </Nodes>
-                      <Edges>
-                        <Edge From="0" To="1" Label="Source1" />
-                      </Edges>
-                    </Workflow>
-                  </Expression>
-                  <Expression xsi:type="Combinator">
-                    <Combinator xsi:type="BooleanProperty">
-                      <Value>true</Value>
-                    </Combinator>
-                  </Expression>
-                  <Expression xsi:type="Combinator">
-                    <Combinator xsi:type="rx:Merge" />
-                  </Expression>
-                  <Expression xsi:type="rx:CreateObservable">
-                    <Name>DelayWithdraw</Name>
-                    <Workflow>
-                      <Nodes>
-                        <Expression xsi:type="WorkflowInput">
-                          <Name>Source1</Name>
-                        </Expression>
-                        <Expression xsi:type="Combinator">
-                          <Combinator xsi:type="rx:Take">
-                            <rx:Count>1</rx:Count>
-                          </Combinator>
-                        </Expression>
-                        <Expression xsi:type="rx:AsyncSubject">
-                          <Name>State</Name>
-                        </Expression>
-                        <Expression xsi:type="SubscribeSubject">
-                          <Name>TaskLogicParameters</Name>
-                        </Expression>
-                        <Expression xsi:type="MemberSelector">
-                          <Selector>OperationControl.MovableSpoutControl</Selector>
-                        </Expression>
-                        <Expression xsi:type="MemberSelector">
-                          <Selector>TimeToCollectAfterReward</Selector>
-                        </Expression>
-                        <Expression xsi:type="scr:ExpressionTransform">
-                          <scr:Name>FromSeconds</scr:Name>
-                          <scr:Expression>TimeSpan.FromSeconds(it)</scr:Expression>
-                        </Expression>
-                        <Expression xsi:type="PropertyMapping">
-                          <PropertyMappings>
-                            <Property Name="DueTime" />
-                          </PropertyMappings>
-                        </Expression>
-                        <Expression xsi:type="Combinator">
-                          <Combinator xsi:type="gl:Timer">
-                            <gl:DueTime>PT0S</gl:DueTime>
-                          </Combinator>
-                        </Expression>
-                        <Expression xsi:type="SubscribeSubject">
-                          <Name>State</Name>
-                        </Expression>
-                        <Expression xsi:type="Combinator">
-                          <Combinator xsi:type="rx:WithLatestFrom" />
-                        </Expression>
-                        <Expression xsi:type="MemberSelector">
-                          <Selector>Item2</Selector>
-                        </Expression>
-                        <Expression xsi:type="WorkflowOutput" />
-                      </Nodes>
-                      <Edges>
-                        <Edge From="0" To="1" Label="Source1" />
-                        <Edge From="1" To="2" Label="Source1" />
-                        <Edge From="3" To="4" Label="Source1" />
-                        <Edge From="4" To="5" Label="Source1" />
-                        <Edge From="5" To="6" Label="Source1" />
-                        <Edge From="6" To="7" Label="Source1" />
-                        <Edge From="7" To="8" Label="Source1" />
-                        <Edge From="8" To="10" Label="Source1" />
-                        <Edge From="9" To="10" Label="Source2" />
-                        <Edge From="10" To="11" Label="Source1" />
-                        <Edge From="11" To="12" Label="Source1" />
-                      </Edges>
-                    </Workflow>
-                  </Expression>
-                  <Expression xsi:type="Combinator">
-                    <Combinator xsi:type="rx:Switch" />
-                  </Expression>
-                  <Expression xsi:type="rx:Condition">
-                    <Name>IsWithdraw?</Name>
-                    <Workflow>
-                      <Nodes>
-                        <Expression xsi:type="WorkflowInput">
-                          <Name>Source1</Name>
-                        </Expression>
-                        <Expression xsi:type="BitwiseNot" />
-                        <Expression xsi:type="WorkflowOutput" />
-                      </Nodes>
-                      <Edges>
-                        <Edge From="0" To="1" Label="Source1" />
-                        <Edge From="1" To="2" Label="Source1" />
-                      </Edges>
-                    </Workflow>
-                  </Expression>
-                  <Expression xsi:type="MulticastSubject">
-                    <Name>SpoutAvailable</Name>
-                  </Expression>
-                  <Expression xsi:type="SubscribeSubject">
-                    <Name>TaskLogicParameters</Name>
-                  </Expression>
-                  <Expression xsi:type="MemberSelector">
-                    <Selector>OperationControl.MovableSpoutControl</Selector>
-                  </Expression>
-                  <Expression xsi:type="MemberSelector">
-                    <Selector>Enabled</Selector>
-                  </Expression>
-                  <Expression xsi:type="rx:Condition">
-                    <Workflow>
-                      <Nodes>
-                        <Expression xsi:type="WorkflowInput">
-                          <Name>Source1</Name>
-                        </Expression>
-                        <Expression xsi:type="WorkflowOutput" />
-                      </Nodes>
-                      <Edges>
-                        <Edge From="0" To="1" Label="Source1" />
-                      </Edges>
-                    </Workflow>
-                  </Expression>
-                  <Expression xsi:type="Combinator">
-                    <Combinator xsi:type="rx:SubscribeWhen" />
-                  </Expression>
-                </Nodes>
-                <Edges>
-                  <Edge From="0" To="1" Label="Source1" />
-                  <Edge From="1" To="6" Label="Source1" />
-                  <Edge From="1" To="7" Label="Source1" />
-                  <Edge From="2" To="3" Label="Source1" />
-                  <Edge From="3" To="4" Label="Source1" />
-                  <Edge From="4" To="5" Label="Source1" />
-                  <Edge From="5" To="6" Label="Source2" />
-                  <Edge From="6" To="7" Label="Source2" />
-                  <Edge From="7" To="8" Label="Source1" />
-                  <Edge From="8" To="9" Label="Source1" />
-                  <Edge From="10" To="11" Label="Source1" />
-                  <Edge From="11" To="12" Label="Source1" />
-                  <Edge From="13" To="14" Label="Source1" />
-                  <Edge From="14" To="15" Label="Source1" />
-                  <Edge From="15" To="16" Label="Source1" />
-                  <Edge From="16" To="17" Label="Source1" />
-                  <Edge From="18" To="19" Label="Source1" />
-                  <Edge From="19" To="23" Label="Source1" />
-                  <Edge From="20" To="21" Label="Source1" />
-                  <Edge From="21" To="22" Label="Source1" />
-                  <Edge From="22" To="23" Label="Source2" />
-                  <Edge From="23" To="24" Label="Source1" />
-                  <Edge From="24" To="25" Label="Source1" />
-                  <Edge From="25" To="26" Label="Source1" />
-                  <Edge From="26" To="27" Label="Source1" />
-                  <Edge From="27" To="32" Label="Source1" />
-                  <Edge From="28" To="29" Label="Source1" />
-                  <Edge From="29" To="30" Label="Source1" />
-                  <Edge From="30" To="31" Label="Source1" />
-                  <Edge From="31" To="32" Label="Source2" />
-                </Edges>
-              </Workflow>
-            </Expression>
-            <Expression xsi:type="SubscribeSubject">
-              <Name>ExperimentCommand</Name>
-            </Expression>
-            <Expression xsi:type="Combinator">
-              <Combinator xsi:type="p1:FilterExperimentCommand">
-                <p1:ExperimentCommand>StartTask</p1:ExperimentCommand>
-              </Combinator>
-            </Expression>
-            <Expression xsi:type="Combinator">
-              <Combinator xsi:type="gl:SampleOnRenderFrame" />
-            </Expression>
-            <Expression xsi:type="Combinator">
-              <Combinator xsi:type="rx:SubscribeWhen" />
-            </Expression>
-          </Nodes>
-          <Edges>
-            <Edge From="0" To="1" Label="Source1" />
-            <Edge From="1" To="2" Label="Source1" />
-            <Edge From="2" To="3" Label="Source1" />
-            <Edge From="4" To="8" Label="Source1" />
-            <Edge From="5" To="6" Label="Source1" />
-            <Edge From="6" To="7" Label="Source1" />
-            <Edge From="7" To="8" Label="Source2" />
-            <Edge From="8" To="9" Label="Source1" />
-            <Edge From="9" To="10" Label="Source1" />
-            <Edge From="10" To="12" Label="Source1" />
-            <Edge From="11" To="12" Label="Source2" />
-            <Edge From="12" To="13" Label="Source1" />
-            <Edge From="13" To="14" Label="Source1" />
-            <Edge From="15" To="19" Label="Source1" />
-            <Edge From="16" To="17" Label="Source1" />
-            <Edge From="17" To="18" Label="Source1" />
-            <Edge From="18" To="19" Label="Source2" />
-          </Edges>
-        </Workflow>
-      </Expression>
-      <Expression xsi:type="GroupWorkflow">
         <Name>FeedbackControl</Name>
         <Workflow>
           <Nodes>
@@ -1400,22 +948,6 @@
             <Expression xsi:type="MulticastSubject">
               <Name>SoftwareEvent</Name>
             </Expression>
-            <Expression xsi:type="SubscribeSubject">
-              <Name>HarpBehaviorEvents</Name>
-            </Expression>
-            <Expression xsi:type="Combinator">
-              <Combinator xsi:type="rx:Take">
-                <rx:Count>1</rx:Count>
-              </Combinator>
-            </Expression>
-            <Expression xsi:type="Combinator">
-              <Combinator xsi:type="BooleanProperty">
-                <Value>true</Value>
-              </Combinator>
-            </Expression>
-            <Expression xsi:type="MulticastSubject">
-              <Name>SpoutAvailable</Name>
-            </Expression>
           </Nodes>
           <Edges>
             <Edge From="1" To="2" Label="Source1" />
@@ -1424,9 +956,6 @@
             <Edge From="5" To="6" Label="Source1" />
             <Edge From="7" To="8" Label="Source1" />
             <Edge From="8" To="9" Label="Source1" />
-            <Edge From="10" To="11" Label="Source1" />
-            <Edge From="11" To="12" Label="Source1" />
-            <Edge From="12" To="13" Label="Source1" />
           </Edges>
         </Workflow>
       </Expression>
@@ -1437,14 +966,14 @@
             <Expression xsi:type="SubscribeSubject">
               <Name>HarpLickometerEvents</Name>
             </Expression>
-            <Expression xsi:type="p6:Parse">
-              <harp:Register xsi:type="p6:TimestampedLickState" />
+            <Expression xsi:type="p5:Parse">
+              <harp:Register xsi:type="p5:TimestampedLickState" />
             </Expression>
             <Expression xsi:type="MemberSelector">
               <Selector>Value</Selector>
             </Expression>
             <Expression xsi:type="BitwiseAnd">
-              <Operand xsi:type="WorkflowProperty" TypeArguments="p6:LickChannels">
+              <Operand xsi:type="WorkflowProperty" TypeArguments="p5:LickChannels">
                 <Value>Channel0</Value>
               </Operand>
             </Expression>
@@ -1719,8 +1248,8 @@
             <Expression xsi:type="SubscribeSubject">
               <Name>HarpSniffDetectorEvents</Name>
             </Expression>
-            <Expression xsi:type="p7:Parse">
-              <harp:Register xsi:type="p7:TimestampedRawVoltage" />
+            <Expression xsi:type="p6:Parse">
+              <harp:Register xsi:type="p6:TimestampedRawVoltage" />
             </Expression>
             <Expression xsi:type="SubscribeSubject">
               <Name>RigSchema</Name>
@@ -1803,10 +1332,10 @@
                       </Edges>
                     </Workflow>
                   </Expression>
-                  <Expression xsi:type="p8:CreateMessage">
+                  <Expression xsi:type="p7:CreateMessage">
                     <harp:MessageType>Write</harp:MessageType>
-                    <harp:Payload xsi:type="p8:CreateTorqueLimitStatePayload">
-                      <p8:TorqueLimitState>0</p8:TorqueLimitState>
+                    <harp:Payload xsi:type="p7:CreateTorqueLimitStatePayload">
+                      <p7:TorqueLimitState>0</p7:TorqueLimitState>
                     </harp:Payload>
                   </Expression>
                   <Expression xsi:type="MulticastSubject">
@@ -1821,8 +1350,8 @@
                       <harp:MessageType>Write</harp:MessageType>
                     </Combinator>
                   </Expression>
-                  <Expression xsi:type="p8:Parse">
-                    <harp:Register xsi:type="p8:TorqueLimitState" />
+                  <Expression xsi:type="p7:Parse">
+                    <harp:Register xsi:type="p7:TorqueLimitState" />
                   </Expression>
                   <Expression xsi:type="Equal">
                     <Operand xsi:type="WorkflowProperty" TypeArguments="sys:Byte">
@@ -1891,8 +1420,8 @@
             <Expression xsi:type="SubscribeSubject">
               <Name>HarpTreadmillEvents</Name>
             </Expression>
-            <Expression xsi:type="p8:Parse">
-              <harp:Register xsi:type="p8:SensorDataDispatchRate" />
+            <Expression xsi:type="p7:Parse">
+              <harp:Register xsi:type="p7:SensorDataDispatchRate" />
             </Expression>
             <Expression xsi:type="rx:BehaviorSubject">
               <Name>TreadmillSamplingRate</Name>
@@ -1957,8 +1486,8 @@
             <Expression xsi:type="SubscribeSubject">
               <Name>HarpTreadmillEvents</Name>
             </Expression>
-            <Expression xsi:type="p8:Parse">
-              <harp:Register xsi:type="p8:TimestampedSensorData" />
+            <Expression xsi:type="p7:Parse">
+              <harp:Register xsi:type="p7:TimestampedSensorData" />
             </Expression>
             <Expression xsi:type="Combinator">
               <Combinator xsi:type="rx:Skip">
@@ -2059,7 +1588,7 @@ Item1 as Displacement,
                     <Combinator xsi:type="rx:ToList" />
                   </Expression>
                   <Expression xsi:type="Combinator">
-                    <Combinator xsi:type="p9:CreateLinear" />
+                    <Combinator xsi:type="p8:CreateLinear" />
                   </Expression>
                   <Expression xsi:type="WorkflowOutput" />
                 </Nodes>
@@ -2083,11 +1612,11 @@ Item1 as Displacement,
               </PropertyMappings>
             </Expression>
             <Expression xsi:type="Combinator">
-              <Combinator xsi:type="p9:Interpolate" />
+              <Combinator xsi:type="p8:Interpolate" />
             </Expression>
-            <Expression xsi:type="p8:Format">
+            <Expression xsi:type="p7:Format">
               <harp:MessageType>Write</harp:MessageType>
-              <harp:Register xsi:type="p8:BrakeCurrentSetPoint" />
+              <harp:Register xsi:type="p7:BrakeCurrentSetPoint" />
             </Expression>
             <Expression xsi:type="rx:CreateObservable">
               <Name>SendMessage</Name>
@@ -2107,8 +1636,8 @@ Item1 as Displacement,
                   <Expression xsi:type="SubscribeSubject">
                     <Name>HarpTreadmillEvents</Name>
                   </Expression>
-                  <Expression xsi:type="p8:Parse">
-                    <harp:Register xsi:type="p8:TimestampedTorque" />
+                  <Expression xsi:type="p7:Parse">
+                    <harp:Register xsi:type="p7:TimestampedTorque" />
                   </Expression>
                   <Expression xsi:type="SubscribeSubject">
                     <Name>HarpMessage</Name>

--- a/src/packages/aind_behavior_vr_foraging/src/aind_behavior_vr_foraging/task_logic.py
+++ b/src/packages/aind_behavior_vr_foraging/src/aind_behavior_vr_foraging/task_logic.py
@@ -977,22 +977,6 @@ Environment = TypeAliasType(
 # ==================== OP CONTROL SPECIFICATIONS ====================
 
 
-class MovableSpoutControl(BaseModel):
-    """
-    Controls the movable water spout behavior for reward delivery.
-
-    This class configures how the movable spout operates, including when it's
-    enabled, timing for reward collection, and retraction distance for operant
-    conditioning protocols.
-    """
-
-    enabled: bool = Field(default=False, description="Whether the movable spout is enabled")
-    time_to_collect_after_reward: float = Field(default=1, ge=0, description="Time (s) to collect after reward")
-    retracting_distance: float = Field(
-        default=0, ge=0, description="The distance, relative to the default position, the spout will be retracted by"
-    )
-
-
 class PositionControl(BaseModel):
     """
     Controls the position tracking and movement detection parameters.
@@ -1049,13 +1033,10 @@ class OperationControl(BaseModel):
     Master control class for all operational hardware systems.
 
     This class aggregates all the hardware control specifications including
-    movable spout, odor delivery, position tracking, and audio systems.
+    odor delivery, position tracking, and audio systems.
     It provides a centralized configuration point for all task hardware.
     """
 
-    movable_spout_control: MovableSpoutControl = Field(
-        default=MovableSpoutControl(), description="Control of the movable spout"
-    )
     odor_control: OdorControl = Field(
         default=OdorControl(target_odor_flow=100, target_total_flow=1000),
         description="Control of the odor",

--- a/src/packages/aind_behavior_vr_foraging_curricula/src/aind_behavior_vr_foraging_curricula/depletion/helpers.py
+++ b/src/packages/aind_behavior_vr_foraging_curricula/src/aind_behavior_vr_foraging_curricula/depletion/helpers.py
@@ -4,11 +4,8 @@ from aind_behavior_vr_foraging import task_logic
 
 def make_default_operation_control(velocity_threshold: float) -> task_logic.OperationControl:
     return task_logic.OperationControl(
-        movable_spout_control=task_logic.MovableSpoutControl(
-            enabled=False,
-        ),
         audio_control=task_logic.AudioControl(duration=0.2, frequency=9999),
-        odor_control=task_logic.OdorControl(valve_max_open_time=10),
+        odor_control=task_logic.OdorControl(),
         position_control=task_logic.PositionControl(
             frequency_filter_cutoff=5,
             velocity_threshold=velocity_threshold,

--- a/src/packages/aind_behavior_vr_foraging_curricula/src/aind_behavior_vr_foraging_curricula/single_site/helpers.py
+++ b/src/packages/aind_behavior_vr_foraging_curricula/src/aind_behavior_vr_foraging_curricula/single_site/helpers.py
@@ -23,7 +23,6 @@ def make_default_operation_control(velocity_threshold: float) -> task_logic.Oper
     """Operation control shared by every stage: movable spout off, audio effectively
     silent, no odor flow, only the stop-velocity threshold varies."""
     return task_logic.OperationControl(
-        movable_spout_control=task_logic.MovableSpoutControl(enabled=False),
         audio_control=task_logic.AudioControl(duration=0.2, frequency=9999),
         odor_control=task_logic.OdorControl(),
         position_control=task_logic.PositionControl(

--- a/src/packages/aind_behavior_vr_foraging_curricula/src/aind_behavior_vr_foraging_curricula/template/stages.py
+++ b/src/packages/aind_behavior_vr_foraging_curricula/src/aind_behavior_vr_foraging_curricula/template/stages.py
@@ -37,15 +37,8 @@ updaters = {
 }
 
 operation_control = vr_task_logic.OperationControl(
-    movable_spout_control=vr_task_logic.MovableSpoutControl(
-        enabled=True,
-        time_to_collect_after_reward=1,
-        retracting_distance=2000,
-    ),
     audio_control=vr_task_logic.AudioControl(frequency=1000, duration=0.2),
-    odor_control=vr_task_logic.OdorControl(
-        valve_max_open_time=100000, target_odor_flow=100, target_total_flow=1000, use_channel_3_as_carrier=True
-    ),
+    odor_control=vr_task_logic.OdorControl(target_odor_flow=100, target_total_flow=1000, use_channel_3_as_carrier=True),
     position_control=vr_task_logic.PositionControl(
         gain=vr_task_logic.Vector3(x=1, y=1, z=1),
         initial_position=vr_task_logic.Vector3(x=0, y=2.56, z=0),


### PR DESCRIPTION
In preparation to fix #567, here we remove the ability to have retraction of the spout during the task. This feature was never used and removing it will make our lives easier going forward in terms of code maintenance. 