### PR TITLE
Fix a bug where failures in wait time validation trigger immediate reward

### DIFF
--- a/src/Extensions/InstantiateSite.bonsai
+++ b/src/Extensions/InstantiateSite.bonsai
@@ -526,6 +526,49 @@ it.Item2 as EntryPosition)</scr:Expression>
                           </Workflow>
                         </Expression>
                         <Expression xsi:type="rx:Condition">
+                          <Name>!IsValidWait?</Name>
+                          <Workflow>
+                            <Nodes>
+                              <Expression xsi:type="WorkflowInput">
+                                <Name>Source1</Name>
+                              </Expression>
+                              <Expression xsi:type="MemberSelector">
+                                <Selector>IsSuccessfulWait</Selector>
+                              </Expression>
+                              <Expression xsi:type="BitwiseNot" />
+                              <Expression xsi:type="WorkflowOutput" />
+                            </Nodes>
+                            <Edges>
+                              <Edge From="0" To="1" Label="Source1" />
+                              <Edge From="1" To="2" Label="Source1" />
+                              <Edge From="2" To="3" Label="Source1" />
+                            </Edges>
+                          </Workflow>
+                        </Expression>
+                        <Expression xsi:type="Combinator">
+                          <Combinator xsi:type="BooleanProperty">
+                            <Value>false</Value>
+                          </Combinator>
+                        </Expression>
+                        <Expression xsi:type="rx:Condition">
+                          <Name>IsValidWait?</Name>
+                          <Workflow>
+                            <Nodes>
+                              <Expression xsi:type="WorkflowInput">
+                                <Name>Source1</Name>
+                              </Expression>
+                              <Expression xsi:type="MemberSelector">
+                                <Selector>IsSuccessfulWait</Selector>
+                              </Expression>
+                              <Expression xsi:type="WorkflowOutput" />
+                            </Nodes>
+                            <Edges>
+                              <Edge From="0" To="1" Label="Source1" />
+                              <Edge From="1" To="2" Label="Source1" />
+                            </Edges>
+                          </Workflow>
+                        </Expression>
+                        <Expression xsi:type="rx:Condition">
                           <Name>Operant</Name>
                           <Workflow>
                             <Nodes>
@@ -1069,24 +1112,28 @@ it.Item2 as EntryPosition)</scr:Expression>
                         <Edge From="11" To="12" Label="Source1" />
                         <Edge From="12" To="13" Label="Source1" />
                         <Edge From="13" To="14" Label="Source1" />
-                        <Edge From="13" To="21" Label="Source1" />
+                        <Edge From="13" To="16" Label="Source1" />
                         <Edge From="14" To="15" Label="Source1" />
-                        <Edge From="15" To="16" Label="Source1" />
-                        <Edge From="15" To="19" Label="Source1" />
+                        <Edge From="15" To="31" Label="Source1" />
                         <Edge From="16" To="17" Label="Source1" />
+                        <Edge From="16" To="24" Label="Source1" />
                         <Edge From="17" To="18" Label="Source1" />
-                        <Edge From="18" To="28" Label="Source1" />
+                        <Edge From="18" To="19" Label="Source1" />
+                        <Edge From="18" To="22" Label="Source1" />
                         <Edge From="19" To="20" Label="Source1" />
-                        <Edge From="20" To="23" Label="Source1" />
-                        <Edge From="21" To="22" Label="Source1" />
-                        <Edge From="22" To="23" Label="Source2" />
-                        <Edge From="23" To="24" Label="Source1" />
+                        <Edge From="20" To="21" Label="Source1" />
+                        <Edge From="21" To="31" Label="Source2" />
+                        <Edge From="22" To="23" Label="Source1" />
+                        <Edge From="23" To="26" Label="Source1" />
                         <Edge From="24" To="25" Label="Source1" />
-                        <Edge From="25" To="26" Label="Source1" />
+                        <Edge From="25" To="26" Label="Source2" />
                         <Edge From="26" To="27" Label="Source1" />
-                        <Edge From="27" To="28" Label="Source2" />
+                        <Edge From="27" To="28" Label="Source1" />
                         <Edge From="28" To="29" Label="Source1" />
                         <Edge From="29" To="30" Label="Source1" />
+                        <Edge From="30" To="31" Label="Source3" />
+                        <Edge From="31" To="32" Label="Source1" />
+                        <Edge From="32" To="33" Label="Source1" />
                       </Edges>
                     </Workflow>
                   </Expression>


### PR DESCRIPTION
Closes #581 
Briefly, the previous task logic had a bug where, if the agent failed to complete the wait period after a stop, the reward would be immediately collected. This resulted in issues like #581 where the subject learned to stop inside a site but would quickly back up to the previous inter-site. This would immediately trigger an invalid wait period (since the animal is now outside the original reward site) and trigger an immediate reward.