### PR TITLE
Fix issue where olfactometers were not logging events

### DIFF
--- a/src/Extensions/Logging.bonsai
+++ b/src/Extensions/Logging.bonsai
@@ -138,7 +138,7 @@
                                 <Name>olfactometerIndex</Name>
                               </Expression>
                               <Expression xsi:type="SubscribeSubject">
-                                <Name>OlfactometerHubCommandsGroupedBy</Name>
+                                <Name>OlfactometerHubEventsGroupedBy</Name>
                               </Expression>
                               <Expression xsi:type="rx:Condition">
                                 <Workflow>


### PR DESCRIPTION
This was a regression introduced by #503. Instead of subscribing to the olfactometer events, we were subscribing to the commands. This led to the acquired data being software-timestamped. In practice, data can still be analyzed but timestamps will be relatively jittered in relation to the real timestamp.