### PR TITLE
Waiting period can also abort if the animal is no longer stopping

### DIFF
--- a/schema/aind_behavior_vr_foraging.json
+++ b/schema/aind_behavior_vr_foraging.json
@@ -3213,7 +3213,7 @@
       "properties": {
         "is_operant": {
           "default": true,
-          "description": "Will the trial implement operant logic",
+          "description": "Will the site implement operant logic",
           "title": "Is Operant",
           "type": "boolean"
         },
@@ -3240,9 +3240,22 @@
         "grace_distance_threshold": {
           "default": 10,
           "description": "Virtual distance (cm) the animal must be within to not abort the current choice",
-          "minimum": 0,
-          "title": "Grace Distance Threshold",
-          "type": "number"
+          "oneOf": [
+            {
+              "minimum": 0,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Grace Distance Threshold"
+        },
+        "abort_on_not_stop": {
+          "default": false,
+          "description": "Whether to abort the waiting period if the animal leaves a stopped state.",
+          "title": "Abort On Not Stop",
+          "type": "boolean"
         }
       },
       "title": "OperantLogic",

--- a/schema/depletion.json
+++ b/schema/depletion.json
@@ -77,7 +77,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Scalar",
@@ -397,7 +398,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Normal",
@@ -735,7 +737,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Normal",
@@ -1036,7 +1039,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Normal",
@@ -1248,7 +1252,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Normal",
@@ -1533,7 +1538,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Normal",
@@ -1745,7 +1751,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Normal",
@@ -1957,7 +1964,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Normal",

--- a/schema/depletion_stops_offset.json
+++ b/schema/depletion_stops_offset.json
@@ -77,7 +77,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Scalar",
@@ -397,7 +398,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Normal",
@@ -735,7 +737,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Normal",
@@ -1036,7 +1039,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Normal",
@@ -1248,7 +1252,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Normal",
@@ -1533,7 +1538,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Normal",
@@ -1745,7 +1751,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Normal",
@@ -1957,7 +1964,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Normal",

--- a/schema/depletion_stops_rate.json
+++ b/schema/depletion_stops_rate.json
@@ -77,7 +77,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Scalar",
@@ -397,7 +398,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Normal",
@@ -735,7 +737,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Normal",
@@ -1036,7 +1039,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Normal",
@@ -1248,7 +1252,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Normal",
@@ -1533,7 +1538,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Normal",
@@ -1745,7 +1751,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Normal",
@@ -1957,7 +1964,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Normal",

--- a/schema/deterministic_reversals.json
+++ b/schema/deterministic_reversals.json
@@ -77,7 +77,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Scalar",
@@ -397,7 +398,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Normal",
@@ -735,7 +737,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Normal",
@@ -1036,7 +1039,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Exponential",
@@ -1252,7 +1256,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Exponential",
@@ -1547,7 +1552,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Exponential",
@@ -1764,7 +1770,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Exponential",
@@ -1986,7 +1993,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Exponential",

--- a/schema/deterministic_reversals_reward_capped.json
+++ b/schema/deterministic_reversals_reward_capped.json
@@ -77,7 +77,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Scalar",
@@ -397,7 +398,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Normal",
@@ -735,7 +737,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Normal",
@@ -1036,7 +1039,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Exponential",
@@ -1252,7 +1256,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Exponential",
@@ -1567,7 +1572,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Exponential",
@@ -1784,7 +1790,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Exponential",
@@ -2026,7 +2033,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Exponential",

--- a/schema/learning_sets.json
+++ b/schema/learning_sets.json
@@ -69,7 +69,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Scalar",
@@ -207,7 +208,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Scalar",
@@ -345,7 +347,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Scalar",
@@ -483,7 +486,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Scalar",
@@ -621,7 +625,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Scalar",
@@ -759,7 +764,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Scalar",
@@ -897,7 +903,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Scalar",
@@ -1035,7 +1042,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Scalar",
@@ -1173,7 +1181,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Scalar",
@@ -1311,7 +1320,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Scalar",
@@ -1449,7 +1459,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Scalar",
@@ -1587,7 +1598,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Scalar",
@@ -1725,7 +1737,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Scalar",
@@ -1863,7 +1876,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Scalar",
@@ -12078,7 +12092,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Scalar",
@@ -12216,7 +12231,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Scalar",
@@ -12354,7 +12370,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Scalar",
@@ -12492,7 +12509,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Scalar",
@@ -12630,7 +12648,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Scalar",
@@ -12768,7 +12787,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Scalar",
@@ -12906,7 +12926,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Scalar",
@@ -13044,7 +13065,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Scalar",
@@ -13182,7 +13204,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Scalar",
@@ -13320,7 +13343,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Scalar",
@@ -13458,7 +13482,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Scalar",
@@ -13596,7 +13621,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Scalar",
@@ -13734,7 +13760,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Scalar",
@@ -13872,7 +13899,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Scalar",

--- a/schema/replenishment_depletion_offset.json
+++ b/schema/replenishment_depletion_offset.json
@@ -77,7 +77,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Scalar",
@@ -397,7 +398,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Normal",
@@ -735,7 +737,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Normal",
@@ -1036,7 +1039,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Scalar",
@@ -1493,7 +1497,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Scalar",
@@ -1830,7 +1835,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Scalar",

--- a/schema/single_site.json
+++ b/schema/single_site.json
@@ -53,7 +53,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Scalar",
@@ -199,7 +200,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Scalar",
@@ -463,7 +465,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Scalar",
@@ -609,7 +612,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Scalar",
@@ -797,7 +801,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Scalar",
@@ -943,7 +948,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Scalar",
@@ -1201,7 +1207,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Exponential",
@@ -1354,7 +1361,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Exponential",
@@ -1507,7 +1515,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Exponential",
@@ -1710,7 +1719,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Exponential",
@@ -1863,7 +1873,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Exponential",
@@ -2016,7 +2027,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Exponential",
@@ -2219,7 +2231,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Exponential",
@@ -2372,7 +2385,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Exponential",
@@ -2525,7 +2539,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Exponential",
@@ -2728,7 +2743,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Exponential",
@@ -2881,7 +2897,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Exponential",
@@ -3034,7 +3051,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Exponential",
@@ -3237,7 +3255,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Exponential",
@@ -3390,7 +3409,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Exponential",
@@ -3543,7 +3563,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Exponential",
@@ -3746,7 +3767,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Exponential",
@@ -3899,7 +3921,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Exponential",
@@ -4052,7 +4075,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Exponential",
@@ -4255,7 +4279,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Exponential",
@@ -4408,7 +4433,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Exponential",
@@ -4561,7 +4587,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Exponential",
@@ -4764,7 +4791,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Exponential",
@@ -4917,7 +4945,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Exponential",
@@ -5070,7 +5099,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Exponential",
@@ -5273,7 +5303,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Exponential",
@@ -5426,7 +5457,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Exponential",
@@ -5579,7 +5611,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Exponential",
@@ -5782,7 +5815,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Exponential",
@@ -5935,7 +5969,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Exponential",
@@ -6088,7 +6123,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Exponential",
@@ -6291,7 +6327,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Exponential",
@@ -6444,7 +6481,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Exponential",
@@ -6597,7 +6635,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Exponential",
@@ -6800,7 +6839,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Exponential",
@@ -6953,7 +6993,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Exponential",
@@ -7106,7 +7147,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Exponential",
@@ -7309,7 +7351,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Exponential",
@@ -7462,7 +7505,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Exponential",
@@ -7615,7 +7659,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Exponential",
@@ -7875,7 +7920,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Exponential",
@@ -8028,7 +8074,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Exponential",
@@ -8181,7 +8228,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Exponential",
@@ -8384,7 +8432,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Exponential",
@@ -8537,7 +8586,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Exponential",
@@ -8690,7 +8740,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Exponential",
@@ -8893,7 +8944,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Exponential",
@@ -9046,7 +9098,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Exponential",
@@ -9199,7 +9252,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Exponential",
@@ -9402,7 +9456,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Exponential",
@@ -9555,7 +9610,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Exponential",
@@ -9708,7 +9764,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Exponential",
@@ -9911,7 +9968,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Exponential",
@@ -10064,7 +10122,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Exponential",
@@ -10217,7 +10276,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Exponential",
@@ -10420,7 +10480,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Exponential",
@@ -10573,7 +10634,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Exponential",
@@ -10726,7 +10788,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Exponential",
@@ -10929,7 +10992,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Exponential",
@@ -11082,7 +11146,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Exponential",
@@ -11235,7 +11300,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Exponential",
@@ -11438,7 +11504,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Exponential",
@@ -11591,7 +11658,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Exponential",
@@ -11744,7 +11812,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Exponential",
@@ -11947,7 +12016,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Exponential",
@@ -12100,7 +12170,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Exponential",
@@ -12253,7 +12324,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Exponential",
@@ -12456,7 +12528,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Exponential",
@@ -12609,7 +12682,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Exponential",
@@ -12762,7 +12836,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Exponential",
@@ -12965,7 +13040,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Exponential",
@@ -13118,7 +13194,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Exponential",
@@ -13271,7 +13348,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Exponential",
@@ -13474,7 +13552,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Exponential",
@@ -13627,7 +13706,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Exponential",
@@ -13780,7 +13860,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Exponential",
@@ -13983,7 +14064,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Exponential",
@@ -14136,7 +14218,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Exponential",
@@ -14289,7 +14372,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 100000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Exponential",

--- a/schema/template.json
+++ b/schema/template.json
@@ -77,7 +77,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 1000000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Exponential",
@@ -333,7 +334,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 1000000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Exponential",
@@ -676,7 +678,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 1000000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Exponential",
@@ -932,7 +935,8 @@
                                                             "scaling_parameters": null
                                                         },
                                                         "time_to_collect_reward": 1000000.0,
-                                                        "grace_distance_threshold": 10.0
+                                                        "grace_distance_threshold": 10.0,
+                                                        "abort_on_not_stop": false
                                                     },
                                                     "delay": {
                                                         "family": "Exponential",

--- a/src/Extensions/AindBehaviorVrForaging.Generated.cs
+++ b/src/Extensions/AindBehaviorVrForaging.Generated.cs
@@ -5068,14 +5068,17 @@ namespace AindVrForagingDataSchema
     
         private double _timeToCollectReward;
     
-        private double _graceDistanceThreshold;
+        private double? _graceDistanceThreshold;
+    
+        private bool _abortOnNotStop;
     
         public OperantLogic()
         {
             _isOperant = true;
             _stopDuration = new AllenNeuralDynamics.AindBehaviorServices.Distributions.Distribution();
             _timeToCollectReward = 100000D;
-            _graceDistanceThreshold = 10D;
+            _graceDistanceThreshold = 10;
+            _abortOnNotStop = false;
         }
     
         protected OperantLogic(OperantLogic other)
@@ -5084,13 +5087,14 @@ namespace AindVrForagingDataSchema
             _stopDuration = other._stopDuration;
             _timeToCollectReward = other._timeToCollectReward;
             _graceDistanceThreshold = other._graceDistanceThreshold;
+            _abortOnNotStop = other._abortOnNotStop;
         }
     
         /// <summary>
-        /// Will the trial implement operant logic
+        /// Will the site implement operant logic
         /// </summary>
         [Newtonsoft.Json.JsonPropertyAttribute("is_operant")]
-        [System.ComponentModel.DescriptionAttribute("Will the trial implement operant logic")]
+        [System.ComponentModel.DescriptionAttribute("Will the site implement operant logic")]
         public bool IsOperant
         {
             get
@@ -5143,7 +5147,7 @@ namespace AindVrForagingDataSchema
         /// </summary>
         [Newtonsoft.Json.JsonPropertyAttribute("grace_distance_threshold")]
         [System.ComponentModel.DescriptionAttribute("Virtual distance (cm) the animal must be within to not abort the current choice")]
-        public double GraceDistanceThreshold
+        public double? GraceDistanceThreshold
         {
             get
             {
@@ -5152,6 +5156,23 @@ namespace AindVrForagingDataSchema
             set
             {
                 _graceDistanceThreshold = value;
+            }
+        }
+    
+        /// <summary>
+        /// Whether to abort the waiting period if the animal leaves a stopped state.
+        /// </summary>
+        [Newtonsoft.Json.JsonPropertyAttribute("abort_on_not_stop")]
+        [System.ComponentModel.DescriptionAttribute("Whether to abort the waiting period if the animal leaves a stopped state.")]
+        public bool AbortOnNotStop
+        {
+            get
+            {
+                return _abortOnNotStop;
+            }
+            set
+            {
+                _abortOnNotStop = value;
             }
         }
     
@@ -5170,7 +5191,8 @@ namespace AindVrForagingDataSchema
             stringBuilder.Append("IsOperant = " + _isOperant + ", ");
             stringBuilder.Append("StopDuration = " + _stopDuration + ", ");
             stringBuilder.Append("TimeToCollectReward = " + _timeToCollectReward + ", ");
-            stringBuilder.Append("GraceDistanceThreshold = " + _graceDistanceThreshold);
+            stringBuilder.Append("GraceDistanceThreshold = " + _graceDistanceThreshold + ", ");
+            stringBuilder.Append("AbortOnNotStop = " + _abortOnNotStop);
             return true;
         }
     

--- a/src/Extensions/InstantiateSite.bonsai
+++ b/src/Extensions/InstantiateSite.bonsai
@@ -285,76 +285,171 @@
                               <Expression xsi:type="rx:AsyncSubject">
                                 <Name>EntryPosition</Name>
                               </Expression>
-                              <Expression xsi:type="SubscribeSubject">
-                                <Name>ThisRewardControl</Name>
-                              </Expression>
-                              <Expression xsi:type="MemberSelector">
-                                <Selector>Delay</Selector>
-                              </Expression>
-                              <Expression xsi:type="SubscribeSubject">
-                                <Name>RngSeed</Name>
-                              </Expression>
-                              <Expression xsi:type="PropertyMapping">
-                                <PropertyMappings>
-                                  <Property Name="RandomSource" />
-                                </PropertyMappings>
-                              </Expression>
-                              <Expression xsi:type="Combinator">
-                                <Combinator xsi:type="p1:SampleDistribution" />
-                              </Expression>
-                              <Expression xsi:type="SubscribeSubject">
-                                <Name>RewardDelayOffset</Name>
-                              </Expression>
-                              <Expression xsi:type="Combinator">
-                                <Combinator xsi:type="rx:CombineLatest" />
-                              </Expression>
-                              <Expression xsi:type="Add" />
-                              <Expression xsi:type="scr:ExpressionTransform">
-                                <scr:Expression>TimeSpan.FromSeconds(it)</scr:Expression>
-                              </Expression>
-                              <Expression xsi:type="PropertyMapping">
-                                <PropertyMappings>
-                                  <Property Name="DueTime" />
-                                </PropertyMappings>
-                              </Expression>
-                              <Expression xsi:type="Combinator">
-                                <Combinator xsi:type="gl:Timer">
-                                  <gl:DueTime>PT0S</gl:DueTime>
-                                </Combinator>
-                              </Expression>
-                              <Expression xsi:type="Combinator">
-                                <Combinator xsi:type="BooleanProperty">
-                                  <Value>true</Value>
-                                </Combinator>
-                              </Expression>
                               <Expression xsi:type="GroupWorkflow">
-                                <Name>CheckDistanceFromEntry</Name>
+                                <Name>TimerCondition</Name>
                                 <Workflow>
                                   <Nodes>
                                     <Expression xsi:type="SubscribeSubject">
-                                      <Name>EntryPosition</Name>
+                                      <Name>ThisRewardControl</Name>
                                     </Expression>
                                     <Expression xsi:type="MemberSelector">
-                                      <Selector>Value</Selector>
-                                    </Expression>
-                                    <Expression xsi:type="MemberSelector">
-                                      <Selector>Z</Selector>
+                                      <Selector>Delay</Selector>
                                     </Expression>
                                     <Expression xsi:type="SubscribeSubject">
-                                      <Name>CurrentPosition</Name>
+                                      <Name>RngSeed</Name>
                                     </Expression>
-                                    <Expression xsi:type="MemberSelector">
-                                      <Selector>Value</Selector>
+                                    <Expression xsi:type="PropertyMapping">
+                                      <PropertyMappings>
+                                        <Property Name="RandomSource" />
+                                      </PropertyMappings>
                                     </Expression>
-                                    <Expression xsi:type="MemberSelector">
-                                      <Selector>Z</Selector>
+                                    <Expression xsi:type="Combinator">
+                                      <Combinator xsi:type="p1:SampleDistribution" />
+                                    </Expression>
+                                    <Expression xsi:type="SubscribeSubject">
+                                      <Name>RewardDelayOffset</Name>
                                     </Expression>
                                     <Expression xsi:type="Combinator">
                                       <Combinator xsi:type="rx:CombineLatest" />
                                     </Expression>
-                                    <Expression xsi:type="Subtract" />
+                                    <Expression xsi:type="Add" />
+                                    <Expression xsi:type="scr:ExpressionTransform">
+                                      <scr:Expression>TimeSpan.FromSeconds(it)</scr:Expression>
+                                    </Expression>
+                                    <Expression xsi:type="PropertyMapping">
+                                      <PropertyMappings>
+                                        <Property Name="DueTime" />
+                                      </PropertyMappings>
+                                    </Expression>
                                     <Expression xsi:type="Combinator">
-                                      <Combinator xsi:type="dsp:Abs" />
+                                      <Combinator xsi:type="gl:Timer">
+                                        <gl:DueTime>PT0S</gl:DueTime>
+                                      </Combinator>
+                                    </Expression>
+                                    <Expression xsi:type="Combinator">
+                                      <Combinator xsi:type="BooleanProperty">
+                                        <Value>true</Value>
+                                      </Combinator>
+                                    </Expression>
+                                    <Expression xsi:type="WorkflowOutput" />
+                                  </Nodes>
+                                  <Edges>
+                                    <Edge From="0" To="1" Label="Source1" />
+                                    <Edge From="1" To="4" Label="Source1" />
+                                    <Edge From="2" To="3" Label="Source1" />
+                                    <Edge From="3" To="4" Label="Source2" />
+                                    <Edge From="4" To="6" Label="Source1" />
+                                    <Edge From="5" To="6" Label="Source2" />
+                                    <Edge From="6" To="7" Label="Source1" />
+                                    <Edge From="7" To="8" Label="Source1" />
+                                    <Edge From="8" To="9" Label="Source1" />
+                                    <Edge From="9" To="10" Label="Source1" />
+                                    <Edge From="10" To="11" Label="Source1" />
+                                    <Edge From="11" To="12" Label="Source1" />
+                                  </Edges>
+                                </Workflow>
+                              </Expression>
+                              <Expression xsi:type="GroupWorkflow">
+                                <Name>DistanceCondition</Name>
+                                <Workflow>
+                                  <Nodes>
+                                    <Expression xsi:type="GroupWorkflow">
+                                      <Name>CheckDistanceFromEntry</Name>
+                                      <Workflow>
+                                        <Nodes>
+                                          <Expression xsi:type="SubscribeSubject">
+                                            <Name>EntryPosition</Name>
+                                          </Expression>
+                                          <Expression xsi:type="MemberSelector">
+                                            <Selector>Value</Selector>
+                                          </Expression>
+                                          <Expression xsi:type="MemberSelector">
+                                            <Selector>Z</Selector>
+                                          </Expression>
+                                          <Expression xsi:type="SubscribeSubject">
+                                            <Name>CurrentPosition</Name>
+                                          </Expression>
+                                          <Expression xsi:type="MemberSelector">
+                                            <Selector>Value</Selector>
+                                          </Expression>
+                                          <Expression xsi:type="MemberSelector">
+                                            <Selector>Z</Selector>
+                                          </Expression>
+                                          <Expression xsi:type="Combinator">
+                                            <Combinator xsi:type="rx:CombineLatest" />
+                                          </Expression>
+                                          <Expression xsi:type="Subtract" />
+                                          <Expression xsi:type="Combinator">
+                                            <Combinator xsi:type="dsp:Abs" />
+                                          </Expression>
+                                          <Expression xsi:type="SubscribeSubject">
+                                            <Name>ThisRewardControl</Name>
+                                          </Expression>
+                                          <Expression xsi:type="MemberSelector">
+                                            <Selector>OperantLogic.GraceDistanceThreshold</Selector>
+                                          </Expression>
+                                          <Expression xsi:type="MemberSelector">
+                                            <Selector>Value</Selector>
+                                          </Expression>
+                                          <Expression xsi:type="PropertyMapping">
+                                            <PropertyMappings>
+                                              <Property Name="Value" />
+                                            </PropertyMappings>
+                                          </Expression>
+                                          <Expression xsi:type="GreaterThan">
+                                            <Operand xsi:type="FloatProperty">
+                                              <Value>0</Value>
+                                            </Operand>
+                                          </Expression>
+                                          <Expression xsi:type="SubscribeSubject">
+                                            <Name>IsInSite</Name>
+                                          </Expression>
+                                          <Expression xsi:type="BitwiseNot" />
+                                          <Expression xsi:type="rx:Condition">
+                                            <Workflow>
+                                              <Nodes>
+                                                <Expression xsi:type="WorkflowInput">
+                                                  <Name>Source1</Name>
+                                                </Expression>
+                                                <Expression xsi:type="WorkflowOutput" />
+                                              </Nodes>
+                                              <Edges>
+                                                <Edge From="0" To="1" Label="Source1" />
+                                              </Edges>
+                                            </Workflow>
+                                          </Expression>
+                                          <Expression xsi:type="Combinator">
+                                            <Combinator xsi:type="BooleanProperty">
+                                              <Value>true</Value>
+                                            </Combinator>
+                                          </Expression>
+                                          <Expression xsi:type="Combinator">
+                                            <Combinator xsi:type="rx:Merge" />
+                                          </Expression>
+                                          <Expression xsi:type="WorkflowOutput" />
+                                        </Nodes>
+                                        <Edges>
+                                          <Edge From="0" To="1" Label="Source1" />
+                                          <Edge From="1" To="2" Label="Source1" />
+                                          <Edge From="2" To="6" Label="Source1" />
+                                          <Edge From="3" To="4" Label="Source1" />
+                                          <Edge From="4" To="5" Label="Source1" />
+                                          <Edge From="5" To="6" Label="Source2" />
+                                          <Edge From="6" To="7" Label="Source1" />
+                                          <Edge From="7" To="8" Label="Source1" />
+                                          <Edge From="8" To="13" Label="Source1" />
+                                          <Edge From="9" To="10" Label="Source1" />
+                                          <Edge From="10" To="11" Label="Source1" />
+                                          <Edge From="11" To="12" Label="Source1" />
+                                          <Edge From="12" To="13" Label="Source2" />
+                                          <Edge From="13" To="18" Label="Source1" />
+                                          <Edge From="14" To="15" Label="Source1" />
+                                          <Edge From="15" To="16" Label="Source1" />
+                                          <Edge From="16" To="17" Label="Source1" />
+                                          <Edge From="17" To="18" Label="Source2" />
+                                          <Edge From="18" To="19" Label="Source1" />
+                                        </Edges>
+                                      </Workflow>
                                     </Expression>
                                     <Expression xsi:type="SubscribeSubject">
                                       <Name>ThisRewardControl</Name>
@@ -362,20 +457,12 @@
                                     <Expression xsi:type="MemberSelector">
                                       <Selector>OperantLogic.GraceDistanceThreshold</Selector>
                                     </Expression>
-                                    <Expression xsi:type="PropertyMapping">
-                                      <PropertyMappings>
-                                        <Property Name="Value" />
-                                      </PropertyMappings>
+                                    <Expression xsi:type="MemberSelector">
+                                      <Selector>HasValue</Selector>
                                     </Expression>
-                                    <Expression xsi:type="GreaterThan">
-                                      <Operand xsi:type="FloatProperty">
-                                        <Value>0</Value>
-                                      </Operand>
+                                    <Expression xsi:type="Combinator">
+                                      <Combinator xsi:type="rx:SubscribeWhen" />
                                     </Expression>
-                                    <Expression xsi:type="SubscribeSubject">
-                                      <Name>IsInSite</Name>
-                                    </Expression>
-                                    <Expression xsi:type="BitwiseNot" />
                                     <Expression xsi:type="rx:Condition">
                                       <Workflow>
                                         <Nodes>
@@ -391,11 +478,57 @@
                                     </Expression>
                                     <Expression xsi:type="Combinator">
                                       <Combinator xsi:type="BooleanProperty">
-                                        <Value>true</Value>
+                                        <Value>false</Value>
                                       </Combinator>
                                     </Expression>
+                                    <Expression xsi:type="WorkflowOutput" />
+                                  </Nodes>
+                                  <Edges>
+                                    <Edge From="0" To="4" Label="Source1" />
+                                    <Edge From="1" To="2" Label="Source1" />
+                                    <Edge From="2" To="3" Label="Source1" />
+                                    <Edge From="3" To="4" Label="Source2" />
+                                    <Edge From="4" To="5" Label="Source1" />
+                                    <Edge From="5" To="6" Label="Source1" />
+                                    <Edge From="6" To="7" Label="Source1" />
+                                  </Edges>
+                                </Workflow>
+                              </Expression>
+                              <Expression xsi:type="GroupWorkflow">
+                                <Name>IsStoppedCondition</Name>
+                                <Workflow>
+                                  <Nodes>
+                                    <Expression xsi:type="SubscribeSubject">
+                                      <Name>IsStopped</Name>
+                                    </Expression>
+                                    <Expression xsi:type="MemberSelector">
+                                      <Selector>Value</Selector>
+                                    </Expression>
+                                    <Expression xsi:type="scr:ExpressionCondition">
+                                      <scr:Name>!it</scr:Name>
+                                      <scr:Expression>!it</scr:Expression>
+                                    </Expression>
+                                    <Expression xsi:type="SubscribeSubject">
+                                      <Name>ThisRewardControl</Name>
+                                    </Expression>
+                                    <Expression xsi:type="MemberSelector">
+                                      <Selector>OperantLogic.AbortOnNotStop</Selector>
+                                    </Expression>
+                                    <Expression xsi:type="rx:Condition">
+                                      <Workflow>
+                                        <Nodes>
+                                          <Expression xsi:type="WorkflowInput">
+                                            <Name>Source1</Name>
+                                          </Expression>
+                                          <Expression xsi:type="WorkflowOutput" />
+                                        </Nodes>
+                                        <Edges>
+                                          <Edge From="0" To="1" Label="Source1" />
+                                        </Edges>
+                                      </Workflow>
+                                    </Expression>
                                     <Expression xsi:type="Combinator">
-                                      <Combinator xsi:type="rx:Merge" />
+                                      <Combinator xsi:type="rx:SubscribeWhen" />
                                     </Expression>
                                     <Expression xsi:type="WorkflowOutput" />
                                   </Nodes>
@@ -407,37 +540,8 @@
                                     <Edge From="4" To="5" Label="Source1" />
                                     <Edge From="5" To="6" Label="Source2" />
                                     <Edge From="6" To="7" Label="Source1" />
-                                    <Edge From="7" To="8" Label="Source1" />
-                                    <Edge From="8" To="12" Label="Source1" />
-                                    <Edge From="9" To="10" Label="Source1" />
-                                    <Edge From="10" To="11" Label="Source1" />
-                                    <Edge From="11" To="12" Label="Source2" />
-                                    <Edge From="12" To="17" Label="Source1" />
-                                    <Edge From="13" To="14" Label="Source1" />
-                                    <Edge From="14" To="15" Label="Source1" />
-                                    <Edge From="15" To="16" Label="Source1" />
-                                    <Edge From="16" To="17" Label="Source2" />
-                                    <Edge From="17" To="18" Label="Source1" />
                                   </Edges>
                                 </Workflow>
-                              </Expression>
-                              <Expression xsi:type="rx:Condition">
-                                <Workflow>
-                                  <Nodes>
-                                    <Expression xsi:type="WorkflowInput">
-                                      <Name>Source1</Name>
-                                    </Expression>
-                                    <Expression xsi:type="WorkflowOutput" />
-                                  </Nodes>
-                                  <Edges>
-                                    <Edge From="0" To="1" Label="Source1" />
-                                  </Edges>
-                                </Workflow>
-                              </Expression>
-                              <Expression xsi:type="Combinator">
-                                <Combinator xsi:type="BooleanProperty">
-                                  <Value>false</Value>
-                                </Combinator>
                               </Expression>
                               <Expression xsi:type="Combinator">
                                 <Combinator xsi:type="rx:Merge" />
@@ -487,34 +591,22 @@ it.Item2 as EntryPosition)</scr:Expression>
                             <Edges>
                               <Edge From="0" To="1" Label="Source1" />
                               <Edge From="1" To="2" Label="Source1" />
-                              <Edge From="3" To="4" Label="Source1" />
-                              <Edge From="4" To="7" Label="Source1" />
-                              <Edge From="5" To="6" Label="Source1" />
-                              <Edge From="6" To="7" Label="Source2" />
+                              <Edge From="3" To="6" Label="Source1" />
+                              <Edge From="4" To="6" Label="Source2" />
+                              <Edge From="5" To="6" Label="Source3" />
+                              <Edge From="6" To="7" Label="Source1" />
                               <Edge From="7" To="9" Label="Source1" />
                               <Edge From="8" To="9" Label="Source2" />
                               <Edge From="9" To="10" Label="Source1" />
+                              <Edge From="9" To="12" Label="Source1" />
                               <Edge From="10" To="11" Label="Source1" />
-                              <Edge From="11" To="12" Label="Source1" />
-                              <Edge From="12" To="13" Label="Source1" />
+                              <Edge From="11" To="13" Label="Source1" />
+                              <Edge From="12" To="13" Label="Source2" />
                               <Edge From="13" To="14" Label="Source1" />
-                              <Edge From="14" To="18" Label="Source1" />
+                              <Edge From="14" To="15" Label="Source1" />
                               <Edge From="15" To="16" Label="Source1" />
                               <Edge From="16" To="17" Label="Source1" />
-                              <Edge From="17" To="18" Label="Source2" />
-                              <Edge From="18" To="19" Label="Source1" />
-                              <Edge From="19" To="21" Label="Source1" />
-                              <Edge From="20" To="21" Label="Source2" />
-                              <Edge From="21" To="22" Label="Source1" />
-                              <Edge From="21" To="24" Label="Source1" />
-                              <Edge From="22" To="23" Label="Source1" />
-                              <Edge From="23" To="25" Label="Source1" />
-                              <Edge From="24" To="25" Label="Source2" />
-                              <Edge From="25" To="26" Label="Source1" />
-                              <Edge From="26" To="27" Label="Source1" />
-                              <Edge From="27" To="28" Label="Source1" />
-                              <Edge From="28" To="29" Label="Source1" />
-                              <Edge From="29" To="30" Label="Source1" />
+                              <Edge From="17" To="18" Label="Source1" />
                             </Edges>
                           </Workflow>
                         </Expression>

--- a/src/packages/aind_behavior_vr_foraging/src/aind_behavior_vr_foraging/task_logic.py
+++ b/src/packages/aind_behavior_vr_foraging/src/aind_behavior_vr_foraging/task_logic.py
@@ -188,7 +188,7 @@ class OperantLogic(BaseModel):
     implementing stopping requirements, collection timeouts, and spatial constraints.
     """
 
-    is_operant: bool = Field(default=True, description="Will the trial implement operant logic")
+    is_operant: bool = Field(default=True, description="Will the site implement operant logic")
     stop_duration: distributions.Distribution = Field(
         default=scalar_value(0),
         validate_default=True,
@@ -197,8 +197,11 @@ class OperantLogic(BaseModel):
     time_to_collect_reward: float = Field(
         default=100000, ge=0, description="Time(s) the animal has to collect the reward"
     )
-    grace_distance_threshold: float = Field(
+    grace_distance_threshold: Optional[float] = Field(
         default=10, ge=0, description="Virtual distance (cm) the animal must be within to not abort the current choice"
+    )
+    abort_on_not_stop: bool = Field(
+        default=False, description="Whether to abort the waiting period if the animal leaves a stopped state."
     )
 
 


### PR DESCRIPTION
Superseeds #568 
Closes #566

Everything is backwards compatible using the default values:

```python
 grace_distance_threshold: Optional[float] = Field(
        default=10, ge=0, description="Virtual distance (cm) the animal must be within to not abort the current choice"
    )
abort_on_not_stop: bool = Field(
    default=False, description="Whether to abort the waiting period if the animal leaves a stopped state."
)
```

grace_distance_threshold can be disabled by setting it to `None` and `abort_on_not_stop` is false by default. 

If `abort_on_not_stop` is set to `True`, the waiting period will abort as soon as the subject stops stopping (!ah!).