### PR TITLE
Ensure manipulator parking positions serialize in a backwards-compatible manner

### DIFF
--- a/scripts/aind.py
+++ b/scripts/aind.py
@@ -1,6 +1,6 @@
 import logging
 from pathlib import Path
-from typing import Any, cast
+from typing import cast
 from aind_behavior_vr_foraging.data_contract.utils import calculate_consumed_water
 
 from aind_behavior_services.rig.aind_manipulator import ManipulatorPosition
@@ -322,10 +322,9 @@ class ByAnimalManipulatorModifier(ByAnimalModifier[AindVrForagingRig]):
             SoftwareEvents,
             _dataset["Behavior"]["SoftwareEvents"]["SpoutParkingPositions"].load(),
         )
-        data: dict[str, Any] = manipulator_parking_position.data.iloc[-1]["data"][
-            "ResetPosition"
-        ]
-        position = ManipulatorPosition.model_validate(data)
+        position = ManipulatorPosition.model_validate(
+            manipulator_parking_position.data.iloc[-1]["data"]
+        )
         return position
 
 

--- a/scripts/aind.py
+++ b/scripts/aind.py
@@ -1,6 +1,6 @@
 import logging
 from pathlib import Path
-from typing import cast
+from typing import Any, cast
 from aind_behavior_vr_foraging.data_contract.utils import calculate_consumed_water
 
 from aind_behavior_services.rig.aind_manipulator import ManipulatorPosition
@@ -322,9 +322,10 @@ class ByAnimalManipulatorModifier(ByAnimalModifier[AindVrForagingRig]):
             SoftwareEvents,
             _dataset["Behavior"]["SoftwareEvents"]["SpoutParkingPositions"].load(),
         )
-        position = ManipulatorPosition.model_validate(
-            manipulator_parking_position.data.iloc[-1]["data"]
-        )
+        data: dict[str, Any] = manipulator_parking_position.data.iloc[-1]["data"][
+            "ResetPosition"
+        ]
+        position = ManipulatorPosition.model_validate(data)
         return position
 
 

--- a/src/Extensions/Logging.bonsai
+++ b/src/Extensions/Logging.bonsai
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<WorkflowBuilder Version="2.9.0"
+<WorkflowBuilder Version="2.9.1"
                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                  xmlns:rx="clr-namespace:Bonsai.Reactive;assembly=Bonsai.Core"
                  xmlns:p1="clr-namespace:AllenNeuralDynamics.Core;assembly=AllenNeuralDynamics.Core"
@@ -1308,6 +1308,13 @@ it.Value.SyncQuadValue.Value as SyncQuadValue)</scr:Expression>
                               <Expression xsi:type="Combinator">
                                 <Combinator xsi:type="rx:Merge" />
                               </Expression>
+                              <Expression xsi:type="scr:ExpressionTransform">
+                                <scr:Name>Label</scr:Name>
+                                <scr:Description>This is meant to ensure backwards compatibility</scr:Description>
+                                <scr:Expression>new(
+it as ResetPosition,
+it as RetractedPosition)</scr:Expression>
+                              </Expression>
                               <Expression xsi:type="Combinator">
                                 <Combinator xsi:type="p1:CreateSoftwareEvent">
                                   <p1:EventName>SpoutParkingPositions</p1:EventName>
@@ -1348,6 +1355,7 @@ it.Value.SyncQuadValue.Value as SyncQuadValue)</scr:Expression>
                               <Edge From="30" To="31" Label="Source3" />
                               <Edge From="31" To="32" Label="Source1" />
                               <Edge From="32" To="33" Label="Source1" />
+                              <Edge From="33" To="34" Label="Source1" />
                             </Edges>
                           </Workflow>
                         </Expression>

--- a/src/main.bonsai
+++ b/src/main.bonsai
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<WorkflowBuilder Version="2.9.0"
+<WorkflowBuilder Version="2.9.1"
                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                  xmlns:p1="clr-namespace:AindVrForagingDataSchema;assembly=Extensions"
                  xmlns:rx="clr-namespace:Bonsai.Reactive;assembly=Bonsai.Core"


### PR DESCRIPTION
This fixes a regression introduced in #595 and ensures that while we removed the parking logic for the manipulator, its serialization remains backwards compatible.